### PR TITLE
Fix build in Conda: reorder includes to Rcpp* is after savvy

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,8 +1,5 @@
 // This includes the main codes to connect C++ and R
 
-// [[Rcpp::depends(RcppArmadillo)]]
-#include <RcppArmadillo.h>
-
 #include <vector>
 #include <thread>         // std::this_thread::sleep_for
 #include <chrono>         // std::chrono::seconds
@@ -24,6 +21,8 @@
 #include "UTIL.hpp"
 #include "CCT.hpp"
 
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
 #include <Rcpp.h>
 #include "getMem.hpp"
 

--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -2,7 +2,6 @@
 #include "savvy/region.hpp"
 #include "variant_group_iterator.hpp"
 
-
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -11,9 +10,9 @@
 #include <cstring>
 #include <limits>
 
-#include <Rcpp.h>
 // [[Rcpp::depends(RcppArmadillo)]]
 #include <RcppArmadillo.h>
+#include <Rcpp.h>
 
 #include "VCF.hpp"
 

--- a/src/VCF.cpp
+++ b/src/VCF.cpp
@@ -1,6 +1,3 @@
-// [[Rcpp::depends(RcppArmadillo)]]
-#include <RcppArmadillo.h>
- 
 #include "savvy/reader.hpp"
 #include "savvy/region.hpp"
 #include "variant_group_iterator.hpp"
@@ -10,11 +7,13 @@
 #include <fstream>
 #include <vector>
 #include <string>
-#include <Rcpp.h>
 #include <stdlib.h>
 #include <cstring>
 #include <limits>
 
+#include <Rcpp.h>
+// [[Rcpp::depends(RcppArmadillo)]]
+#include <RcppArmadillo.h>
 
 #include "VCF.hpp"
 


### PR DESCRIPTION
Reorder includes so that RcppArmadillo is last. This allows savvy to build, which cannot build if it is imported after RcppArmadillo.h

This fixes https://github.com/saigegit/SAIGE/issues/17, and is the workaround that I'm using to build this inside of our conda environment. 

I don't know what style you want includes in, but I'd be glad to update this to match any preferred include style.