### PR TITLE
fix: Build inside of conda

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -2,7 +2,7 @@ PKG_CPPFLAGS = \
 -I ../thirdParty/cget/include \
 -I ../thirdParty/cget/lib \
 -I ../thirdParty/cget/lib64 \
--D SQLITE_ENABLE_COLUMN_METADATA -O3 -fpic -Wall -Wextra -pedantic  -DARMA_64BIT_WORD=1
+-D SQLITE_ENABLE_COLUMN_METADATA -O3 -fpic -Wall -Wextra -pedantic  -DARMA_64BIT_WORD=1 -D__STDC_FORMAT_MACROS
 
 CXX_STD = CXX11 
 


### PR DESCRIPTION
Fixes https://github.com/saigegit/SAIGE/issues/17

Add D__STDC_FORMAT_MACROS to the Makevars, enabling compilation inside of conda environments which use glibc 2.12 headers.

There's a couple of ways to fix this, including manual ordering of includes such that Rcpp is always included after savvy, but I feel like this is the safest path.

I could write a small essay about the details of this issue, but the big picture is that the conda-forge r-base package uses headers from glibc 2.12, which are so old that they follow the C99 standard, meaning that the formatting macros will not be defined when building with C++ unless __STDC_FORMAT_MACROS is set.

This issue doesn't occur in any environment with a more recent `<inttypes.h>` header, including CentOS 7 and newer and any currently supported Ubuntu, but conda-forge is shipping a CentOS 6 sysroot, which causes this issue to occur: https://conda-forge.org/docs/user/announcements.html#id2

Example from LLVM headers of a similar fix: https://reviews.llvm.org/D24921

```
// C99 7.8.1 Macros for format specifiers
//
//  Footnote 191: C++ implementations should define these macros only when
//  __STDC_FORMAT_MACROS is defined before <inttypes.h> is included.
//
// C++11 [c.files]p3:
//
//  The macros defined by <cinttypes> are provided unconditionally.
//  In particular, the symbol __STDC_FORMAT_MACROS (mentioned
//  in footnote 182 of the C standard) plays no role in C++.
//
// C11 removed the problematic footnotes.
//
// Work around this inconsistency by always defining those macros in C++ mode,
// so that a C library implementation which follows the C99 standard can be
// used in C++.
```