### PR TITLE
fix: crash in efficient resampling

### DIFF
--- a/src/ER_binary_func.cpp
+++ b/src/ER_binary_func.cpp
@@ -195,6 +195,11 @@ double SKATExactBin_Work(arma::mat & Z, arma::vec & res, arma::vec & pi1, uint32
 	arma::mat Z1temp2 = (Z_1 % (1-p1)).t();
 	arma::vec Z1 =  arma::vectorise(Z1temp2);
 
+    // We cannot take the mean of an empty vector
+    if (p1.size() == 0) {
+        return 0.0;
+    }
+
 	uint32_t m = Z_1.n_cols;
 	int k = idx.n_elem;
 	std::vector<int> n_total_k(k+1, 0);


### PR DESCRIPTION
@weizhouUMICH @saigegit 

Return a p-value of 0 for ER SKATExactBin_Work when we have no data to act on. Works around a crash in efficient resampling.

I don't know enough about the method to know if this is the right solution. Maybe we want to return NaN, maybe we want to return infinity, maybe we want to throw an exception and try a different approach entirely? We've got a dataset that fails here because p1 is empty and thus we cannot take the mean of it: https://github.com/saigegit/SAIGE/issues/88