### PR TITLE
Update ComputeExact to use vectors rather than raw memory where easy

### DIFF
--- a/src/Binary_ComputeExact.cpp
+++ b/src/Binary_ComputeExact.cpp
@@ -28,7 +28,7 @@ double     ComputeExact::CalTestStat(int k, int * array, bool is_save,bool is_mi
 
 	int i, j, l, temp;
     double stat = 0;
-    memcpy(m_teststat_one, m_teststat_Z0, sizeof(double) *m_m);
+    memcpy(m_teststat_one.data(), m_teststat_Z0.data(), sizeof(double) *m_m);
 	
     for(i=0;i< k;i++){
         l = array[i];
@@ -55,7 +55,7 @@ double     ComputeExact::CalTestStat_INV(int k, int * array, bool is_save, bool 
     
 	int i, j, l, temp;
     double stat = 0;
-    memcpy(m_teststat_one, m_teststat_Z1, sizeof(double) *m_m);
+    memcpy(m_teststat_one.data(), m_teststat_Z1.data(), sizeof(double) *m_m);
 	
     for(i=0;i< k;i++){
         l = array[i];
@@ -78,7 +78,7 @@ double     ComputeExact::CalTestStat_INV(int k, int * array, bool is_save, bool 
 }
 
 
-int     ComputeExact::CalFisherProb(int k, int * array){
+int     ComputeExact::CalFisherProb(int k, vector<int> array){
 
 	int i,l;
 	double temp = 1;
@@ -94,7 +94,7 @@ int     ComputeExact::CalFisherProb(int k, int * array){
 }
 
 
-int     ComputeExact::CalFisherProb_INV(int k, int * array){
+int     ComputeExact::CalFisherProb_INV(int k, vector<int> & array){
     
 	int i,l, k1;
     k1 = m_k - k;
@@ -111,13 +111,13 @@ int     ComputeExact::CalFisherProb_INV(int k, int * array){
 }
 
 
-int     ComputeExact::SKAT_Exact_Recurse(int k, int * array, int cell, int start, int end){
+int     ComputeExact::SKAT_Exact_Recurse(int k, vector<int> & array, int cell, int start, int end){
 
 	int i;
 	
 	/* node */
 	if(k == cell){
-		CalTestStat(k, array);
+		CalTestStat(k, array.data());
 		CalFisherProb(k, array);
 		m_idx++;
 	} else {
@@ -131,13 +131,13 @@ int     ComputeExact::SKAT_Exact_Recurse(int k, int * array, int cell, int start
 }
 
 
-int     ComputeExact::SKAT_Exact_Recurse_INV(int k, int * array, int cell, int start, int end){
+int     ComputeExact::SKAT_Exact_Recurse_INV(int k, vector<int> & array, int cell, int start, int end){
     
 	int i;
 
 	/* node */
 	if(k == cell){
-		CalTestStat_INV(k, array);
+		CalTestStat_INV(k, array.data());
 		CalFisherProb_INV(k, array);
 		m_idx++;
 	} else {
@@ -151,13 +151,13 @@ int     ComputeExact::SKAT_Exact_Recurse_INV(int k, int * array, int cell, int s
 }
 
 
-int     ComputeExact::SKAT_Resampling(int k, int * array){
+int     ComputeExact::SKAT_Resampling(int k, vector<int> & array){
     
     int k1 = m_k-k;
     if(k <= m_k/2 +1){
         for(int i=0;i< m_total_k[k];i++){
             SL_Sample(k, m_k, m_temp_x, array);
-            CalTestStat(k, m_temp_x);
+            CalTestStat(k, m_temp_x.data());
             CalFisherProb(k, m_temp_x);
             m_idx++;
         }
@@ -165,7 +165,7 @@ int     ComputeExact::SKAT_Resampling(int k, int * array){
         
         for(int i=0;i< m_total_k[k];i++){
             SL_Sample(k1, m_k, m_temp_x, array);
-            CalTestStat_INV(k1, m_temp_x);
+            CalTestStat_INV(k1, m_temp_x.data());
             CalFisherProb_INV(k1, m_temp_x);
             m_idx++;
         }
@@ -176,13 +176,13 @@ int     ComputeExact::SKAT_Resampling(int k, int * array){
 }
 
 
-int     ComputeExact::SKAT_Resampling_Random(int k, int * array){
+int     ComputeExact::SKAT_Resampling_Random(int k, std::vector<int> & array){
     
     int err;
     int k1 = m_k-k;
     if(k <= m_k/2 +1){
         for(int i=0;i< m_total_k[k];i++){
-            SL_Binary_Boot1(m_k, k, m_p1.data(), array, m_temp_x1, m_temp_x, &err);
+            SL_Binary_Boot1(m_k, k, m_p1, array, m_temp_x1, m_temp_x, &err);
             CalFisherProb(k, m_temp_x);
             
             m_fprob[m_idx] = 1;
@@ -194,7 +194,7 @@ int     ComputeExact::SKAT_Resampling_Random(int k, int * array){
         
         for(int i=0;i< m_total_k[k];i++){
             
-            SL_Binary_Boot1(m_k, k1, m_p1_inv.data(), array, m_temp_x1, m_temp_x, &err);
+            SL_Binary_Boot1(m_k, k1, m_p1_inv, array, m_temp_x1, m_temp_x, &err);
             CalFisherProb_INV(k1, m_temp_x);
             
             m_fprob[m_idx] = 1;
@@ -217,47 +217,9 @@ int     ComputeExact::SKAT_Resampling_Random(int k, int * array){
 
 
 ComputeExact::ComputeExact(){
-  
-    m_fprob=NULL;
-    m_teststat=NULL;    
-    m_Z0=NULL;
-    m_Z1=NULL;
-    
-    m_teststat_one=NULL;
-    m_teststat_Z0=NULL;
-    m_teststat_Z1=NULL;
-    
-    m_pprod=1;
-    
-    m_temp_x=NULL;
-    m_temp_x1=NULL;
-}
 
-ComputeExact::~ComputeExact(){
-    
-    
-	SL_free(m_fprob);
-	SL_free(m_teststat);
-	SL_free(m_teststat_one);
-    
-	SL_free(m_Z0);
-	SL_free(m_Z1);
-	SL_free(m_teststat_Z0);
-    SL_free(m_teststat_Z1);
-    SL_free(m_temp_x);  
-    SL_free(m_temp_x1);
-    
-    m_fprob = NULL;
-    m_teststat=NULL;
-    m_teststat_one=NULL;
-    
-    m_Z0=NULL;
-    m_Z1=NULL;
-    m_teststat_Z0=NULL;
-    m_teststat_Z1=NULL;
-    m_temp_x=NULL;
-    m_temp_x1=NULL;
-    
+    m_pprod=1;
+
 }
 
 /************************************************
@@ -278,7 +240,7 @@ ComputeExact::~ComputeExact(){
 *
 ******************************************************/
 
-int     ComputeExact::Init(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double epsilon, bool IsSmallmemory){
+int     ComputeExact::Init(vector<int> resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double epsilon, bool IsSmallmemory){
 
 
     int i, idx, k1;
@@ -290,7 +252,7 @@ int     ComputeExact::Init(int * resarray, int nres, int * nres_k, double * Z0, 
     idx = 0;
     for(i=0;i<nres;i++){
     
-        array = (resarray + idx) ;
+        array = (resarray.data() + idx) ;
         k1 = nres_k[i];
         idx += k1;
         
@@ -337,16 +299,18 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
  
 
 	
-	m_Z0 = (double *) SL_calloc(m_k * m_m, sizeof(double));
-	m_Z1 = (double *) SL_calloc(m_k * m_m, sizeof(double));	
-	m_teststat_Z0 = (double *) SL_calloc(m_m, sizeof(double));
-    m_teststat_Z1 = (double *) SL_calloc(m_m, sizeof(double));
+	m_Z0.reserve(m_k * m_m);
+	m_Z1.reserve(m_k * m_m);
+	m_teststat_Z0.reserve(m_m);
+    m_teststat_Z1.reserve(m_m);
 	
-	memcpy(m_Z0, Z0, sizeof(double) * m_k * m_m);
-	memcpy(m_Z1, Z1, sizeof(double) * m_k * m_m);
-    
-    memset(m_teststat_Z0,0, sizeof(double)*m_m);
-    memset(m_teststat_Z1,0, sizeof(double)*m_m);
+	memcpy(m_Z0.data(), Z0, sizeof(double) * m_k * m_m);
+	memcpy(m_Z1.data(), Z1, sizeof(double) * m_k * m_m);
+
+    // Instead of this we could just resize the vector?
+    // We shouldn't need to manually zero it out anyway.
+    memset(m_teststat_Z0.data(),0, sizeof(double)*m_m);
+    memset(m_teststat_Z1.data(),0, sizeof(double)*m_m);
 	/* generate prob matrix */
 	for(i=0;i< m_k;i++){
 		int idx = i*m_m;
@@ -360,19 +324,19 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
 	}
 	
     if(!m_IsSmallmemory){
-        m_fprob = (double *) SL_calloc(m_total, sizeof(double));
-        m_teststat = (double *) SL_calloc(m_total, sizeof(double));
+        m_fprob.reserve(m_total);
+        m_teststat.reserve(m_total);
     } else {
         
-        m_fprob = NULL;
-        m_teststat = NULL;
+        m_fprob.clear();
+        m_teststat.clear();
         
     }
     
-	m_teststat_one = (double *) SL_calloc(m_m, sizeof(double));	
-	memset(m_teststat, 0, m_total * sizeof(double));
-    m_temp_x = (int *) SL_calloc(m_k, sizeof(int));
-    m_temp_x1 = (int *) SL_calloc(m_k, sizeof(int));
+	m_teststat_one.reserve(m_m);
+	memset(m_teststat.data(), 0, m_total * sizeof(double));
+    m_temp_x.reserve(m_k);
+    m_temp_x1.reserve(m_k);
     
     return 1;
 }
@@ -388,13 +352,12 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
 int     ComputeExact::Run(int test_type){
    
     int i, j, idx, l;
-    int * array = (int *) SL_calloc(m_k, sizeof(int));
+    vector<int> array(m_k);
     //SL_setseed(time(NULL));
 	SL_setseed(1);
   
 	for(i=0;i < m_k+1;i++){
         
-        memset(array, 0, sizeof(int)* m_k);
         if(m_IsExact[i] == 1){
             if(i <= m_k/2 +1){
                 SKAT_Exact_Recurse(i, array, 0, 0, m_k);
@@ -413,8 +376,6 @@ int     ComputeExact::Run(int test_type){
         }
 	}
 
-    SL_free(array);
-    
 	//Rprintf("2, m_idx[%d], total[%d]\n", m_idx, m_total);
 	
    

--- a/src/Binary_ComputeExact.cpp
+++ b/src/Binary_ComputeExact.cpp
@@ -28,23 +28,23 @@ double     ComputeExact::CalTestStat(int k, int * array, bool is_save,bool is_mi
 
 	int i, j, l, temp;
     double stat = 0;
-    memcpy(m_teststat_one.data(), m_teststat_Z0.data(), sizeof(double) *m_m);
-	
+    m_teststat_one = m_teststat_Z0;
+
     for(i=0;i< k;i++){
         l = array[i];
         temp = l*m_m;
         for(j=0;j< m_m;j++){
-            m_teststat_one[j]+=m_Z1[temp+j] - m_Z0[temp+j] ;
+            m_teststat_one.at(j) += m_Z1.at(temp +j) - m_Z0.at(temp + j);
         }
     }
 
 	for(j=0;j< m_m;j++){
-        stat +=m_teststat_one[j] * m_teststat_one[j];
+        stat +=m_teststat_one.at(j)* m_teststat_one.at(j);
 	}
     
     //stat=log(stat);
     if(is_save){
-        m_teststat[m_idx]=stat ;
+        m_teststat.at(m_idx) = stat ;
     }
     return stat;
 
@@ -55,42 +55,42 @@ double     ComputeExact::CalTestStat_INV(int k, int * array, bool is_save, bool 
     
 	int i, j, l, temp;
     double stat = 0;
-    memcpy(m_teststat_one.data(), m_teststat_Z1.data(), sizeof(double) *m_m);
+    m_teststat_one = m_teststat_Z1;
 	
     for(i=0;i< k;i++){
         l = array[i];
         temp = l*m_m;
         for(j=0;j< m_m;j++){
-            m_teststat_one[j]+=m_Z0[temp+j] - m_Z1[temp+j] ;
+            m_teststat_one.at(j) += m_Z0.at(temp+j) - m_Z1.at(temp+j);
         }
     }
     
 	for(j=0;j< m_m;j++){
-		stat+=m_teststat_one[j] * m_teststat_one[j];
+		stat+=m_teststat_one.at(j) * m_teststat_one.at(j);
 	}
     
     //stat=log(stat);
     if(is_save){
-        m_teststat[m_idx]=stat ;
+        m_teststat.at(m_idx)=stat ;
     }
     return stat;
     
 }
 
 
-int     ComputeExact::CalFisherProb(int k, vector<int> array){
+int     ComputeExact::CalFisherProb(int k, vector<int> & array){
 
 	int i,l;
 	double temp = 1;
 	for(i=0;i< k;i++){
-		l = array[i];
-		temp = temp * m_odds[l];
+		l = array.at(i);
+		temp = temp * m_odds.at(l);
 	}
-	m_fprob[m_idx] = temp;
-    m_denomi[k] = m_denomi[k]+temp;
+	m_fprob.at(m_idx) = temp;
+    m_denomi.at(k) = m_denomi.at(k) + temp;
 	
     return 0;
-		
+
 }
 
 
@@ -100,11 +100,11 @@ int     ComputeExact::CalFisherProb_INV(int k, vector<int> & array){
     k1 = m_k - k;
 	double temp = m_pprod;
 	for(i=0;i< k;i++){
-		l = array[i];
-		temp = temp / m_odds[l];
+        l = array.at(i);
+		temp = temp / m_odds.at(l);
 	}
-	m_fprob[m_idx] = temp;
-    m_denomi[k1] = m_denomi[k1]+temp;
+	m_fprob.at(m_idx) = temp;
+    m_denomi.at(k1) = m_denomi.at(k1)+temp;
 	
     return 0;
     
@@ -122,7 +122,7 @@ int     ComputeExact::SKAT_Exact_Recurse(int k, vector<int> & array, int cell, i
 		m_idx++;
 	} else {
 		 for(i=start; i<end; i++) {
-            array[cell] = i;
+            array.at(cell) = i;
             SKAT_Exact_Recurse(k, array, cell+1, i+1, end);
         }
 	
@@ -142,7 +142,7 @@ int     ComputeExact::SKAT_Exact_Recurse_INV(int k, vector<int> & array, int cel
 		m_idx++;
 	} else {
         for(i=start; i<end; i++) {
-            array[cell] = i;
+            array.at(cell) = i;
             SKAT_Exact_Recurse_INV(k, array, cell+1, i+1, end);
         }
         
@@ -155,7 +155,7 @@ int     ComputeExact::SKAT_Resampling(int k, vector<int> & array){
     
     int k1 = m_k-k;
     if(k <= m_k/2 +1){
-        for(int i=0;i< m_total_k[k];i++){
+        for(int i=0;i< m_total_k.at(k);i++){
             SL_Sample(k, m_k, m_temp_x, array);
             CalTestStat(k, m_temp_x.data());
             CalFisherProb(k, m_temp_x);
@@ -163,7 +163,7 @@ int     ComputeExact::SKAT_Resampling(int k, vector<int> & array){
         }
     } else {
         
-        for(int i=0;i< m_total_k[k];i++){
+        for(int i=0;i< m_total_k.at(k);i++){
             SL_Sample(k1, m_k, m_temp_x, array);
             CalTestStat_INV(k1, m_temp_x.data());
             CalFisherProb_INV(k1, m_temp_x);
@@ -181,24 +181,24 @@ int     ComputeExact::SKAT_Resampling_Random(int k, std::vector<int> & array){
     int err;
     int k1 = m_k-k;
     if(k <= m_k/2 +1){
-        for(int i=0;i< m_total_k[k];i++){
+        for(int i=0;i< m_total_k.at(k);i++){
             SL_Binary_Boot1(m_k, k, m_p1, array, m_temp_x1, m_temp_x, &err);
             CalFisherProb(k, m_temp_x);
-            
-            m_fprob[m_idx] = 1;
-            m_denomi[k] = m_denomi[k]+1;
-            
+
+            m_fprob.at(m_idx) = 1;
+            m_denomi.at(k) = m_denomi.at(k)+1;
+
             m_idx++;
         }
     } else {
-        
-        for(int i=0;i< m_total_k[k];i++){
-            
+
+        for(int i=0;i< m_total_k.at(k);i++){
+
             SL_Binary_Boot1(m_k, k1, m_p1_inv, array, m_temp_x1, m_temp_x, &err);
             CalFisherProb_INV(k1, m_temp_x);
-            
-            m_fprob[m_idx] = 1;
-            m_denomi[k] = m_denomi[k]+1;
+
+            m_fprob.at(m_idx) = 1;
+            m_denomi.at(k) = m_denomi.at(k)+1;
             
             m_idx++;
         }
@@ -251,7 +251,8 @@ int     ComputeExact::Init(vector<int> resarray, int nres, int * nres_k, double 
     
     idx = 0;
     for(i=0;i<nres;i++){
-    
+
+        // Can this pointer go stale? Does resarray get appended to / reallocated past here?
         array = (resarray.data() + idx) ;
         k1 = nres_k[i];
         idx += k1;
@@ -299,24 +300,20 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
  
 
 	
-	m_Z0.reserve(m_k * m_m);
-	m_Z1.reserve(m_k * m_m);
-	m_teststat_Z0.reserve(m_m);
-    m_teststat_Z1.reserve(m_m);
-	
-	memcpy(m_Z0.data(), Z0, sizeof(double) * m_k * m_m);
-	memcpy(m_Z1.data(), Z1, sizeof(double) * m_k * m_m);
+	m_Z0.resize(m_k * m_m);
+	m_Z1.resize(m_k * m_m);
+	m_teststat_Z0.resize(m_m);
+    m_teststat_Z1.resize(m_m);
 
-    // Instead of this we could just resize the vector?
-    // We shouldn't need to manually zero it out anyway.
-    memset(m_teststat_Z0.data(),0, sizeof(double)*m_m);
-    memset(m_teststat_Z1.data(),0, sizeof(double)*m_m);
+    memcpy(m_Z0.data(), Z0, sizeof(double) * m_k * m_m);
+    memcpy(m_Z1.data(), Z1, sizeof(double) * m_k * m_m);
+
 	/* generate prob matrix */
 	for(i=0;i< m_k;i++){
 		int idx = i*m_m;
 		for(j=0;j< m_m;j++){
-			m_teststat_Z0[j]+=m_Z0[idx+j];
-            m_teststat_Z1[j]+=m_Z1[idx+j];
+			m_teststat_Z0.at(j)+=m_Z0.at(idx+j);
+            m_teststat_Z1.at(j)+=m_Z1.at(idx+j);
 		}
         
         // debug
@@ -324,8 +321,8 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
 	}
 	
     if(!m_IsSmallmemory){
-        m_fprob.reserve(m_total);
-        m_teststat.reserve(m_total);
+        m_fprob.resize(m_total);
+        m_teststat.resize(m_total);
     } else {
         
         m_fprob.clear();
@@ -333,10 +330,9 @@ int     ComputeExact::SaveParam(double * Z0, double *Z1, int k, int m, int total
         
     }
     
-	m_teststat_one.reserve(m_m);
-	memset(m_teststat.data(), 0, m_total * sizeof(double));
-    m_temp_x.reserve(m_k);
-    m_temp_x1.reserve(m_k);
+	m_teststat_one.resize(m_m);
+    m_temp_x.resize(m_k);
+    m_temp_x1.resize(m_k);
     
     return 1;
 }
@@ -358,13 +354,13 @@ int     ComputeExact::Run(int test_type){
   
 	for(i=0;i < m_k+1;i++){
         
-        if(m_IsExact[i] == 1){
+        if(m_IsExact.at(i) == 1){
             if(i <= m_k/2 +1){
                 SKAT_Exact_Recurse(i, array, 0, 0, m_k);
             } else {
                 SKAT_Exact_Recurse_INV(m_k - i, array, 0, 0, m_k);
             }
-        } else if( m_total_k[i] < MIN_SIM1 && test_type == 3) {
+        } else if( m_total_k.at(i) < MIN_SIM1 && test_type == 3) {
             
             SKAT_Resampling_Random(i, array);
 
@@ -384,22 +380,22 @@ int     ComputeExact::Run(int test_type){
     double total_prob_sum = 0;
 	for(i=0;i < m_k+1;i++){
 
-		for(j=idx;j< idx + m_total_k[i];j++){
+		for(j=idx;j< idx + m_total_k.at(i);j++){
             
-            m_fprob[j] = m_fprob[j] / m_denomi[i] * m_prob_k[i];
-            total_prob_sum += m_fprob[j];
+            m_fprob.at(j) = m_fprob.at(j) / m_denomi.at(i) * m_prob_k.at(i);
+            total_prob_sum += m_fprob.at(j);
 		}	
-		idx = idx + m_total_k[i];
+		idx = idx + m_total_k.at(i);
 	}
     idx=0;
 	for(i=0;i < m_k+1;i++){
-        m_prob_k[i] = 0;
-		for(j=idx;j< idx + m_total_k[i];j++){
-            m_fprob[j] = m_fprob[j] / total_prob_sum;
-            m_prob_k[i] += m_fprob[j]; // for debugging
+        m_prob_k.at(i) = 0;
+		for(j=idx;j< idx + m_total_k.at(i);j++){
+            m_fprob.at(j) = m_fprob.at(j) / total_prob_sum;
+            m_prob_k.at(i) += m_fprob.at(j); // for debugging
 		}	
-        //Rprintf("[%d:%e]", i, m_prob_k[i]);
-		idx = idx + m_total_k[i];
+        //Rprintf(".at(%d:%e)", i, m_prob_k.at(i));
+		idx = idx + m_total_k.at(i);
 	}
 
     
@@ -415,7 +411,7 @@ int     ComputeExact::Run(int test_type){
 		for(i=0;i<m_total ; i++){
             
                         
-            temp1 = m_Q[l] - m_teststat[i];
+            temp1 = m_Q.at(l) - m_teststat.at(i);
             //Rprintf("[%e][%e][%e][%e]\n", m_Q[l],m_teststat[i], temp1);
             
             if(fabs(temp1) <= m_epsilon){
@@ -423,10 +419,10 @@ int     ComputeExact::Run(int test_type){
             }
             //Rprintf("[%e][%e][%e]\n",  temp1, fabs(temp1), m_epsilon);
             if(temp1 <= 0){
-				n_num += m_fprob[i] ;
+				n_num += m_fprob.at(i) ;
 				//Rprintf("C\n");
 				if( temp1 == 0 ){
-					n_same += m_fprob[i] ;
+					n_same += m_fprob.at(i) ;
 					//Rprintf("D\n");
 				}
 			}  
@@ -439,20 +435,20 @@ int     ComputeExact::Run(int test_type){
 		//Rprintf("[%e][%e][%d]\n", m_pval[l], m_pval_same[l], l);
 	}
 
-    m_LargestQ=m_teststat[0];
+    m_LargestQ=m_teststat.at(0);
     m_minP= 0;
     for(i=0;i<m_total ; i++){
         
-        temp1 = m_LargestQ - m_teststat[i];
+        temp1 = m_LargestQ - m_teststat.at(i);
         if(fabs(temp1) <= m_epsilon){
             temp1=  0;
         }
 
         if(temp1 < 0){
-            m_LargestQ = m_teststat[i];
-            m_minP = m_fprob[i] ;
+            m_LargestQ = m_teststat.at(i);
+            m_minP = m_fprob.at(i) ;
         } else if( temp1 == 0 ){
-            m_minP += m_fprob[i] ;
+            m_minP += m_fprob.at(i) ;
            
         }
     }

--- a/src/Binary_ComputeExact.hpp
+++ b/src/Binary_ComputeExact.hpp
@@ -14,7 +14,7 @@ public:
     ComputeExact();
     ~ComputeExact();
     
-    int     Init(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total
+    int     Init(std::vector<int> resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total
              , int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double epsilon, bool IsSmallmemory=0);
 
     
@@ -27,24 +27,24 @@ protected:
     virtual double     CalTestStat(int k, int * array, bool is_save=true, bool is_minIdx = false, int * minIdx = NULL);
     virtual double     CalTestStat_INV(int k, int * array, bool is_save=true, bool is_minIdx = false, int * minIdx = NULL);
     
-    int     CalFisherProb(int k, int * array);
-    int     SKAT_Exact_Recurse(int k, int * array, int cell, int start, int end);
-    int     SKAT_Resampling(int k, int * array);
-    int     SKAT_Resampling_Random(int k, int * array);    
+    int     CalFisherProb(int k, vector<int> array);
+    int     SKAT_Exact_Recurse(int k, vector<int> & array, int cell, int start, int end);
+    int     SKAT_Resampling(int k, vector<int> & array);
+    int     SKAT_Resampling_Random(int k, vector<int> & array);
 
-    int     CalFisherProb_INV(int k, int * array);
-    int     SKAT_Exact_Recurse_INV(int k, int * array, int cell, int start, int end);
+    int     CalFisherProb_INV(int k, vector<int> & array);
+    int     SKAT_Exact_Recurse_INV(int k, vector<int> & array, int cell, int start, int end);
     
 protected:
 
-    double * m_fprob ;	/* fisher hg probability */
-    double * m_teststat;	/* test statistic */
-    double * m_Z0;		/* Z0 and Z1 matrix */
-    double * m_Z1;
+    vector<double> m_fprob ;	/* fisher hg probability */
+    vector<double> m_teststat;	/* test statistic */
+    vector<double> m_Z0;		/* Z0 and Z1 matrix */
+    vector<double> m_Z1;
 
-    double * 	m_teststat_one;
-    double * 	m_teststat_Z0;
-    double *    m_teststat_Z1;
+    vector<double> 	m_teststat_one;
+    vector<double> 	m_teststat_Z0;
+    vector<double>    m_teststat_Z1;
 
     int m_k;				/* # of samples to have at least one minor allele */
     int m_m;				/* # of markers */
@@ -62,8 +62,8 @@ protected:
     vector<double> m_logOdds;
     
     int m_idx;
-    int * m_temp_x;
-    int * m_temp_x1;
+    vector<int> m_temp_x;
+    vector<int> m_temp_x1;
     
     // OUTput
     vector<double>  m_pval;

--- a/src/Binary_ComputeExact.hpp
+++ b/src/Binary_ComputeExact.hpp
@@ -12,8 +12,7 @@ class ComputeExact {
  
 public: 
     ComputeExact();
-    ~ComputeExact();
-    
+
     int     Init(std::vector<int> resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total
              , int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double epsilon, bool IsSmallmemory=0);
 
@@ -27,7 +26,7 @@ protected:
     virtual double     CalTestStat(int k, int * array, bool is_save=true, bool is_minIdx = false, int * minIdx = NULL);
     virtual double     CalTestStat_INV(int k, int * array, bool is_save=true, bool is_minIdx = false, int * minIdx = NULL);
     
-    int     CalFisherProb(int k, vector<int> array);
+    int     CalFisherProb(int k, vector<int> & array);
     int     SKAT_Exact_Recurse(int k, vector<int> & array, int cell, int start, int end);
     int     SKAT_Resampling(int k, vector<int> & array);
     int     SKAT_Resampling_Random(int k, vector<int> & array);
@@ -89,8 +88,7 @@ class ComputeExactSKATO : public ComputeExact {
 
 public: 
     ComputeExactSKATO() ;
-    ~ComputeExactSKATO(){};
-    
+
     int     Init(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, double * r_corr, int n_r, double * param, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double epsilon, bool IsSmallmemory=0);
 
 protected:
@@ -103,8 +101,8 @@ protected:
 protected:
     /* for SKAT-O */
     vector<double>  m_rcorr;
-    double * m_Z0_C;		
-    double * m_Z1_C;    
+    vector<double> m_Z0_C;
+    vector<double> m_Z1_C;
     double 	m_teststat_Z0_C;
     double  m_teststat_Z1_C;
     

--- a/src/Binary_ComputeExactSKATO.cpp
+++ b/src/Binary_ComputeExactSKATO.cpp
@@ -62,7 +62,7 @@ double ComputeExactSKATO::CalTestStat
     double test_C  = m_teststat_Z0_C;
     double test_skat = 0;
     double teststat;
-    memcpy(m_teststat_one, m_teststat_Z0, sizeof(double) *m_m);
+    memcpy(m_teststat_one.data(), m_teststat_Z0.data(), sizeof(double) *m_m);
     
 	
     for(i=0;i< k;i++){
@@ -131,7 +131,8 @@ double      ComputeExactSKATO::CalTestStat_INV(int k, int * array, bool is_save,
     double test_C  = m_teststat_Z1_C;
     double test_skat = 0;
     double teststat;
-    memcpy(m_teststat_one, m_teststat_Z1, sizeof(double) *m_m);
+    // There are easier ways to copy vectors
+    memcpy(m_teststat_one.data(), m_teststat_Z1.data(), sizeof(double) *m_m);
     
     for(i=0;i< k;i++){
         l = array[i];
@@ -196,19 +197,8 @@ double      ComputeExactSKATO::CalTestStat_INV(int k, int * array, bool is_save,
 
 
 ComputeExactSKATO::ComputeExactSKATO(){
-  
-    
-    m_fprob=NULL;
-    m_teststat=NULL;    
-    m_Z0=NULL;
-    m_Z1=NULL;
-    
-    m_teststat_one=NULL;
-    m_teststat_Z0=NULL;
-    m_teststat_Z1=NULL;
     
     m_pprod=1;
-
 
 }
 /*

--- a/src/Binary_ComputeExactSKATO.cpp
+++ b/src/Binary_ComputeExactSKATO.cpp
@@ -25,10 +25,10 @@ double     ComputeExactSKATO::Cal_Pvalue_Rcorr(double test_skat, double test_C, 
     
     double pval=0;
     double Qnorm= 0;
-    double rho = m_rcorr[idx];
-    double muQ = m_muQ[idx];
-    double varQ = m_varQ[idx];
-    double df = m_df[idx];
+    double rho = m_rcorr.at(idx);
+    double muQ = m_muQ.at(idx);
+    double varQ = m_varQ.at(idx);
+    double df = m_df.at(idx);
     
     double Q = (1-rho) * test_skat + rho * test_C ;
     //Rprintf("Param: %d-[%f][%f][%f]\n",idx, Q, test_skat,test_C );
@@ -62,20 +62,19 @@ double ComputeExactSKATO::CalTestStat
     double test_C  = m_teststat_Z0_C;
     double test_skat = 0;
     double teststat;
-    memcpy(m_teststat_one.data(), m_teststat_Z0.data(), sizeof(double) *m_m);
-    
+    m_teststat_one = m_teststat_Z0;
 	
     for(i=0;i< k;i++){
         l = array[i];
         temp = l*m_m;
         for(j=0;j< m_m;j++){
-            m_teststat_one[j]+=m_Z1[temp+j] - m_Z0[temp+j] ;
+            m_teststat_one.at(j)+=m_Z1.at(temp+j) - m_Z0.at(temp+j) ;
         }
-        test_C += m_Z1_C[l] - m_Z0_C[l] ;
+        test_C += m_Z1_C.at(l) - m_Z0_C.at(l) ;
     }
     
 	for(j=0;j< m_m;j++){
-		test_skat+=m_teststat_one[j] * m_teststat_one[j];
+		test_skat+=m_teststat_one.at(j) * m_teststat_one.at(j);
 	}
     test_C = test_C * test_C;
     
@@ -103,7 +102,7 @@ double ComputeExactSKATO::CalTestStat
     
     /* since larger Q has a smaller p-value, it should be -teststat, not teststat */
     if(is_save){
-        m_teststat[m_idx] = -teststat;  
+        m_teststat.at(m_idx) = -teststat;  
         
     }
 /*    
@@ -131,21 +130,20 @@ double      ComputeExactSKATO::CalTestStat_INV(int k, int * array, bool is_save,
     double test_C  = m_teststat_Z1_C;
     double test_skat = 0;
     double teststat;
-    // There are easier ways to copy vectors
-    memcpy(m_teststat_one.data(), m_teststat_Z1.data(), sizeof(double) *m_m);
+    m_teststat_one = m_teststat_Z1;
     
     for(i=0;i< k;i++){
         l = array[i];
         temp = l*m_m;
         for(j=0;j< m_m;j++){
-            m_teststat_one[j]+=m_Z0[temp+j] - m_Z1[temp+j] ;
+            m_teststat_one.at(j)+=m_Z0.at(temp+j) - m_Z1.at(temp+j) ;
         }
-        test_C += m_Z0_C[l] - m_Z1_C[l] ;
+        test_C += m_Z0_C.at(l) - m_Z1_C.at(l) ;
     }
     test_C = test_C * test_C;
     
 	for(j=0;j< m_m;j++){
-		test_skat+=m_teststat_one[j] * m_teststat_one[j];
+		test_skat+=m_teststat_one.at(j) * m_teststat_one.at(j);
 	}
     
     for(i=0; i<m_rcorr.size(); i++){
@@ -201,13 +199,7 @@ ComputeExactSKATO::ComputeExactSKATO(){
     m_pprod=1;
 
 }
-/*
-ComputeExactSKATO::~ComputeExactSKATO(){
-    
-    
 
-}
-*/
 /************************************************
 *
 *	Init function
@@ -239,22 +231,20 @@ int     ComputeExactSKATO::Init(int * resarray, int nres, int * nres_k, double *
         m_teststat_Z0_C = 0;
         m_teststat_Z1_C = 0;
         
-        m_Z0_C = (double *) SL_calloc(m_k * 1, sizeof(double));
-        m_Z1_C = (double *) SL_calloc(m_k * 1, sizeof(double));	
-        memset(m_Z0_C,0, sizeof(double)*m_k);
-        memset(m_Z1_C,0, sizeof(double)*m_k);
+        m_Z0_C.resize(m_k * 1);
+        m_Z1_C.resize(m_k * 1);
         
         for(i=0;i<m_k;i++){
             int idx = i*m_m;
             for(j=0;j<m_m;j++){
-                m_Z0_C[i]+=m_Z0[idx+j];
-                m_Z1_C[i]+=m_Z1[idx+j];
+                m_Z0_C.at(i)+=m_Z0.at(idx+j);
+                m_Z1_C.at(i)+=m_Z1.at(idx+j);
             }
             
         }
         for(i=0;i<m_k;i++){
-            m_teststat_Z0_C += m_Z0_C[i];
-            m_teststat_Z1_C += m_Z1_C[i];
+            m_teststat_Z0_C += m_Z0_C.at(i);
+            m_teststat_Z1_C += m_Z1_C.at(i);
         }
         
     }

--- a/src/Binary_Permu_SKAT.cpp
+++ b/src/Binary_Permu_SKAT.cpp
@@ -163,7 +163,7 @@ int Binary_Permu_SKAT::Get_TestStat(int idx, bool is_org){
         
         
     } else {
-        SL_GetPermu(m_nSample, m_Y.data(), m_buf.data());
+        SL_GetPermu(m_nSample, m_Y, m_buf);
         pY = (int *) m_Y.data();
         
     }

--- a/src/Binary_global.cpp
+++ b/src/Binary_global.cpp
@@ -43,7 +43,7 @@ void SL_free(void * ptr){
     
 }
 
-void SL_Sample(int k, int n, int *y, int *x){
+void SL_Sample(int k, int n, vector<int> & y, std::vector<int> & x){
     
     int i, j;
     
@@ -66,7 +66,7 @@ void SL_Sample(int k, int n, int *y, int *x){
     Interface
  *********************************************************/
 
-void SKAT_Exact(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double * pval, double *pval_same, double *minP, int test_type, double epsilon)
+void SKAT_Exact(std::vector<int> & resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double * pval, double *pval_same, double *minP, int test_type, double epsilon)
 {
     
     class ComputeExact exact;

--- a/src/Binary_global.hpp
+++ b/src/Binary_global.hpp
@@ -1,21 +1,22 @@
 #ifndef GLOBAL_001 
 #define GLOBAL_001 
 
+#include <vector>
 
 void * SL_calloc(size_t num, size_t size);
 void SL_free(void * ptr);
-void SL_Sample(int k, int n, int *y, int *x);
+void SL_Sample(int k, int n, std::vector<int> & y, std::vector<int> & x);
 
 
-void SL_Binary_Boot1(int n, int ncase, double * pcase, int * buf1, int * buf2, int * z_one, int *err);
+void SL_Binary_Boot1(int n, int ncase, std::vector<double> & pcase, std::vector<int> & buf1, std::vector<int> & buf2, std::vector<int> & z_one, int *err);
 double SL_runif_double();
 int SL_runif_INT(int max);
 void  SL_setseed(int seed);
 void  SL_out();
-void SL_GetSample(int n, int k, int *y, int *x);
-void SL_GetPermu(int n, int *y, int *x);
+void SL_GetSample(int n, int k, std::vector<int> & y, std::vector<int> & x);
+void SL_GetPermu(int n, std::vector<int> & y, std::vector<int> & x);
 
-void SKAT_Exact(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double * pval, double *pval_same, double *minP, int test_type, double epsilon);
+void SKAT_Exact(std::vector<int> & resarray, int nres, int * nres_k, double * Z0, double *Z1, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double * pval, double *pval_same, double *minP, int test_type, double epsilon);
 
 void SKATO_Exact(int * resarray, int nres, int * nres_k, double * Z0, double *Z1, double * r_corr, int n_r,
                  double * param, int k, int m, int total, int * total_k, double *prob_k, double * odds, double * p1, int * IsExact, double * pval, double *pval_same, double *minP, int test_type, double epsilon);

--- a/src/Binary_resampling.cpp
+++ b/src/Binary_resampling.cpp
@@ -2,11 +2,13 @@
 
     #include <R.h>
     #include <Rmath.h>
-    
+
 #endif
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "Binary_global.hpp"
 
 /*********************************************************************
 
@@ -21,11 +23,11 @@ double SL_runif_double(){
         val = unif_rand();
     #endif
     return val ;
- 
+
 }
 
 int SL_runif_INT(int max){
-    
+
     int val ;
 #ifdef _STAND_ALONE_
     val=rand() % max;
@@ -33,7 +35,7 @@ int SL_runif_INT(int max){
     val = floor(unif_rand() * (double) max);
 #endif
     return val ;
-    
+
 }
 
 int SL_runif_int(int max){
@@ -45,7 +47,7 @@ int SL_runif_int(int max){
 
 
 void  SL_setseed(int seed){
-  
+
     #ifdef _STAND_ALONE_
         srand ( seed );
     #else
@@ -54,7 +56,7 @@ void  SL_setseed(int seed){
 }
 
 void  SL_out(){
-    
+
     #ifndef _STAND_ALONE_
         PutRNGstate();
     #endif
@@ -69,9 +71,9 @@ void  SL_out(){
 	x : buffer
 */
 
-void SL_GetSample(int n, int k, int *y, int *x){
+void SL_GetSample(int n, int k, std::vector<int> & y, std::vector<int> & x){
     int i, j;
-    
+
     for (i = 0; i < n; i++){
         x[i] = i;
     }
@@ -82,14 +84,14 @@ void SL_GetSample(int n, int k, int *y, int *x){
     }
 }
 
-void SL_GetPermu(int n, int *y, int *x){
+void SL_GetPermu(int n, std::vector<int> & y, std::vector<int> & x){
     int i, j;
-    
+
     for (i = 0; i < n; i++){
         x[i] = y[i];
     }
     for (i = 0; i < n; i++) {
-        
+
         j = SL_runif_INT(n);
         y[i] = x[j] ;
         x[j] = x[--n];
@@ -102,17 +104,17 @@ void SL_GetPermu(int n, int *y, int *x){
     ncase : number of cases
     pcase : prob to be case
     buf1 : buffer of length n
-    buf2 : buffer of length n 
+    buf2 : buffer of length n
     z_one : output of length n
     err: error code
- 
+
  */
 
-void SL_Binary_Boot1(int n, int ncase, double * pcase, int * buf1, int * buf2, int * z_one, int *err){
+void SL_Binary_Boot1(int n, int ncase, std::vector<double> & pcase, std::vector<int> & buf1, std::vector<int> & buf2, std::vector<int> & z_one, int *err){
 
 	int i, i1,j,k, n1, ncase1;
 	double temp;
-    
+
 	SL_GetSample(n, n, buf1, buf2);
 	ncase1 = 0;
 	n1 = n;
@@ -130,8 +132,8 @@ void SL_Binary_Boot1(int n, int ncase, double * pcase, int * buf1, int * buf2, i
 			}
 			if(ncase1 == ncase)
 				break;
-		} 
-		
+		}
+
 		if(ncase1 == ncase){
 			break;
 		} else if(ncase1 > ncase) {
@@ -139,260 +141,40 @@ void SL_Binary_Boot1(int n, int ncase, double * pcase, int * buf1, int * buf2, i
 			return;
 		} else {
 			n1 = n - ncase1;
-			memcpy(buf1, buf2, sizeof(int) * n1);		
+			memcpy(buf1.data(), buf2.data(), sizeof(int) * n1);
 		}
 	}
-	
+
 	if(ncase != ncase1){
 		*err = -1;
         /*
         printf("Error! [%d][%d][%d]\n", n, ncase, ncase1);
         for(i=0;i<n;i++){
-            
+
             printf("[%e]",pcase[i]);
         }
         printf("\n");
         */
-        
+
 		return;
 	}
-	
+
 	*err=1;
 	return;
 
 }
 
-
-
-void SL_Binary_Boot_2(int * pn, int * pm, int *pncase, double * pcase, int * buf1, int * buf2, int *Z, int *err ){
-
-	int i, n, m, ncase, idx;
-	int * z_one;
-	n = *pn;
-	m = *pm;
-	ncase = *pncase;
-	
-    SL_setseed(100);
-
-	
-	for(i=0;i<m;i++){
-	
-		idx = i * n ;
-		z_one = &(Z[idx]);
-		SL_Binary_Boot1(n, ncase, pcase, buf1, buf2, z_one, err);
-		if(*err == -1){
-			SL_out();
-			return;
-		}
-	}
-	
-	SL_out();
-	return;
-}
-
-
-void Test1(int * pn, int * pm, int *pncase, double * pcase, int * buf1, int * buf2, int *buf3){
+void Test1(int * pn, int * pm, int *pncase, double * pcase, std::vector<int> & buf1, std::vector<int> & buf2, int *buf3){
 
 	int i, n, m, ncase, idx;
 	n = *pn;
 	m = *pm;
 	ncase = *pncase;
-	
+
 	for(i=0;i<m;i++){
-	
+
 		idx = i * n ;
 		/*SL_Binary_Boot1(n, ncase, pcase, buf1, buf2, buf3);*/
 		SL_GetSample(n, n, buf1, buf2);
 	}
 }
-
-
-
-int  CalTestStat(double * Z0, double *Z1, double * teststat_Z0, 
-                     double * teststat_one, int m, int n, int * array, 
-                     double * pQ, int is_inverse){
-    
-    
-	int i, j, temp, arr1;
-    double test_skat = 0;
-
-    arr1=1;
-    if(is_inverse > 0){
-        arr1=0;
-    }
-    
-	
-    memcpy(teststat_one, teststat_Z0, sizeof(double) * m); 
-     
-    for(i=0;i< n;i++){
-        
-        if(array[i]== arr1){
-            temp = i*m;
-            for(j=0;j< m;j++){
-                /*printf("[%d][%d][%d][%e][%e]\n",i, array[i], j, teststat_one[j], Z1[temp+j] - Z0[temp+j]);*/
-                teststat_one[j]+=Z1[temp+j] - Z0[temp+j] ;
-                
-            }
-        }
-    }
-   
-	for(j=0;j< m;j++){
-		test_skat+=teststat_one[j] * teststat_one[j];
-	}
-    
-    pQ[0]= test_skat; 
-    
-    /*printf("|%e|\n",test_skat);*/
-    return 1;
-}
-
-
-// int     ComputeExactSKATO::CalTestStat(int k, int * array){
-int  CalTestStat_O(double * Z0, double *Z1, double * Z0_C, double * Z1_C, 
-                     double * teststat_Z0, double teststat_Z0_C, 
-                     double * teststat_one, int m, int n, int * array, 
-                     double * r_corr, int n_r, double * pQ, int is_inverse){
-    
-    
-	int i, j, temp, arr1;
-    double test_C  = teststat_Z0_C;
-    double test_skat = 0;
-   
-    
-    if(n_r == 1){
-        int re;
-        re = CalTestStat(Z0, Z1, teststat_Z0, teststat_one, m, n, array, pQ, is_inverse);
-        return re;
-    }
-    
-    memcpy(teststat_one, teststat_Z0, sizeof(double) * m);
-    
-    arr1=1;
-    if(is_inverse > 0){
-        arr1=0;
-    }
-	
-    for(i=0;i< n;i++){
-        
-        if(array[i]== arr1){
-            temp = i*m;
-            for(j=0;j< m;j++){
-                teststat_one[j]+=Z1[temp+j] - Z0[temp+j] ;
-            }
-            test_C += Z1_C[i] - Z0_C[i] ;
-        }
-    }
-    
-	for(j=0;j< m;j++){
-		test_skat+=teststat_one[j] * teststat_one[j];
-	}
-    test_C = test_C * test_C;
-    
-    for(i=0;i<n_r;i++){
-        pQ[i] = (1-r_corr[i]) * test_skat + r_corr[i] * test_C;
-        
-    }
-    
-    return n_r;
-}
-
-void ResampleSTAT_1(double * Z0, double *Z1, double * Z0_C, double * Z1_C, 
-                  double * teststat_Z0, double *teststat_Z1, double *pteststat_Z0_C, double *pteststat_Z1_C,
-                  double * r_corr, int *pn_r, int *pk, int *pm, int * pn,
-                  int * total_k, int * ncase_k, double * p1,
-                  int *buf1, int * buf2, int *buf3, double * teststat_one, /* buffers */
-                  double * Q, int *err)
-{
-  
-    double teststat_Z0_C, teststat_Z1_C;
-    int n_r, k, m, n;
-    int i,j, idx, idx1;
-    double *pQ = Q;
-    
-    teststat_Z0_C = pteststat_Z0_C[0]; 
-    teststat_Z1_C = pteststat_Z1_C[0]; 
-    n_r = pn_r[0]; k=pk[0]; m=pm[0]; n=pn[0];
-    
-    *err=1;
-    SL_setseed(100);
-    
-    /* printf("Start[%d]!\n",k);*/
-    idx=0;
-    for(i=0;i<=k;i++){
-        
-        int is_sampling=1;
-        int is_inverse =0;
-        
-        double * Z0_1=Z0;
-        double * Z1_1=Z1;
-        double * Z0_C_1=Z0_C;
-        double * Z1_C_1=Z1_C;
-        double * teststat_Z0_1=teststat_Z0;
-        double teststat_Z0_C_1 = teststat_Z0_C;
-        
-        
-        /*printf("[%d][%d]!\n",i, total_k[i]);*/
-        if(ncase_k[i] == 0){
-            for(j=0;j< n;j++){
-                buf3[j]= 0;
-            }
-            is_sampling=0;
-                
-        } else if(ncase_k[i] == n){
-            for(j=0;j< n;j++){
-                buf3[j]= 1;
-            }
-            is_sampling=0;
-            is_inverse=1;
-                
-        } else { 
-            if(ncase_k[i] *2 > n) {
-                is_inverse=1;
-            }
-            double sum1=0;
-            for(j=0;j<n;j++){
-                sum1 += p1[j];
-            }
-            for(j=0;j<n;j++){
-                p1[j] = p1[j] /sum1 * ((double) ncase_k[i]);
-            }           
-        } 
-        
-        if(is_inverse > 0){
-            
-            Z0_1=Z1;
-            Z1_1=Z0;
-            Z0_C_1=Z1_C;
-            Z1_C_1=Z0_C;
-            teststat_Z0_1=teststat_Z1;
-            teststat_Z0_C_1 = teststat_Z1_C;
-            
-        }
-        
-        for(j=0;j< total_k[i]; j++){
-            
-            if(is_sampling){
-                memset(buf3, 0, sizeof(int) * n);
-                SL_Binary_Boot1(n, ncase_k[i], p1, buf1, buf2, buf3, err);
-                if(*err == -1){
-                    SL_out();
-                    return;
-                }
-            }
-            
-            idx1 = CalTestStat_O(Z0_1, Z1_1, Z0_C_1, Z1_C_1, teststat_Z0_1, teststat_Z0_C_1
-                                 , teststat_one, m, n, buf3, r_corr, n_r, &(pQ[idx]), is_inverse);
-            
-            idx+=idx1;
-             
-        }
-         
-
-    }
-    
-    SL_out();
-    return;
-    
-    
-}
-

--- a/src/ER_binary_func.cpp
+++ b/src/ER_binary_func.cpp
@@ -242,7 +242,7 @@ double SKATExactBin_Work(arma::mat & Z, arma::vec & res, arma::vec & pi1, uint32
 	//istdvec IsExactstd = arma::conv_to< istdvec >::from(pr["IsExact"]);
 
 
-	SKAT_Exact(&resarray[0], nres, &nres_k[0], &Z0std[0], &Z1std[0], k, m, n_total, &n_total_k[0], &prob[0], &oddsstd[0], &p1_adjstd[0], &IsExactVec[0], &pval[0], &pval1[0], &minP, test_type_new, epsilon);
+	SKAT_Exact(resarray, nres, &nres_k[0], &Z0std[0], &Z1std[0], k, m, n_total, &n_total_k[0], &prob[0], &oddsstd[0], &p1_adjstd[0], &IsExactVec[0], &pval[0], &pval1[0], &minP, test_type_new, epsilon);
 
 	//arma::mat pval_re(pval.size(),2);
 


### PR DESCRIPTION
I've seen several people running into memory corruption issues out of ComputeExact and associated classes: 
https://github.com/saigegit/SAIGE/issues/69
https://github.com/saigegit/SAIGE/issues/83

It would be much easier to find and correct the underlying problems if C++ vectors were used instead of calloc and free, and I don't see any reason why that couldn't be done.

This changes some of the easiest to update arrays to be vectors instead. If you think this is a good idea, there's more to improve memory safety that could be done.