### PR TITLE
Update superlu versioning

### DIFF
--- a/thirdParty/requirements.txt
+++ b/thirdParty/requirements.txt
@@ -1,2 +1,2 @@
 statgen/savvy@v2.1.0
-xiaoyeli/superlu
+xiaoyeli/superlu@b814567e6cdeba61edffe45839a4043a46215c7a

--- a/thirdParty/requirements.txt
+++ b/thirdParty/requirements.txt
@@ -1,2 +1,2 @@
 statgen/savvy@v2.1.0
-xiaoyeli/superlu@b6177d0b743c0f1f6765db535dd8b6ce30c00061
+xiaoyeli/superlu


### PR DESCRIPTION
Update superlu commit tag for Mac compatibility. Broken build due to known superlu issue (https://github.com/xiaoyeli/superlu/issues/91) that was fixed in superlu version 6. SAIGE does not build on updated Mac clang compilers using the older superlu version.