### PR TITLE
bugfix: remove lib.loc from public run scripts

### DIFF
--- a/extdata/step1_fitNULLGLMM.R
+++ b/extdata/step1_fitNULLGLMM.R
@@ -3,7 +3,7 @@
 options(stringsAsFactors=F)
 
 ## load R libraries
-library(SAIGE, lib.loc="/humgen/atgu1/fin/wzhou/tools/GATE_SAIGE/install_1.4.1/")
+library(SAIGE)
 require(optparse) #install.packages("optparse")
 
 print(sessionInfo())

--- a/extdata/step2_SPAtests_new.R
+++ b/extdata/step2_SPAtests_new.R
@@ -3,7 +3,7 @@
 #options(stringsAsFactors=F, scipen = 999)
 options(stringsAsFactors=F)
 #library(SAIGE, lib.loc="/humgen/atgu1/fin/wzhou/tools/GATE_SAIGE/install/SAIGE_GATE")
-library(SAIGE, lib.loc="/humgen/atgu1/fin/wzhou/tools/GATE_SAIGE/install_1.4.1")
+library(SAIGE)
 BLASctl_installed <- require(RhpcBLASctl)
 library(optparse)
 library(data.table)


### PR DESCRIPTION
Looks like some local pathing was accidentally pushed uncommented