### PR TITLE
updated tbb and added osx-arm64 support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,8 @@ RUN curl -fsSL https://pixi.sh/install.sh | sh && \
 
 RUN curl -L https://github.com/chrchang/plink-ng/archive/refs/tags/v2.0.0-a.6.16.tar.gz | tar -zx && \
     mv plink-ng-2.0.0-a.6.16 plink-ng && \
-    pixi run x86_64-conda-linux-gnu-cc -std=c++14 -fPIC -O3 -I.pixi/envs/default/include -L.pixi/envs/default/lib -o plink2_includes.a plink-ng/2.0/include/*.cc -shared -lz -lzstd -lpthread -lm -ldeflate && \
-    mv plink2_includes.a .pixi/envs/default/lib
+    pixi run x86_64-conda-linux-gnu-cc -std=c++14 -fPIC -O3 -I.pixi/envs/default/include -L.pixi/envs/default/lib -o libplink2_includes.a plink-ng/2.0/include/*.cc -shared -lz -lzstd -lpthread -lm -ldeflate && \
+    mv libplink2_includes.a .pixi/envs/default/lib
 
 RUN pixi run R CMD INSTALL .
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,7 +1,7 @@
 [workspace]
 channels = ["conda-forge", "bioconda"]
 name = "SAIGE"
-platforms = ["linux-64", "osx-64"]
+platforms = ["linux-64", "osx-64", "osx-arm64"]
 version = "0.1.0"
 
 [tasks]
@@ -30,4 +30,4 @@ savvy = "*"
 superlu = "*"
 zlib = "*"
 zstd = "*"
-tbb = "<2021"
+tbb = "*"

--- a/src/Makevars
+++ b/src/Makevars
@@ -5,7 +5,7 @@ CXX_STD = CXX14
 PKG_LIBS = $(ZLIB_LIB) $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) -lsuperlu -lzstd -llapack
 
 PKG_CPPFLAGS += -I../.pixi/envs/default/include -I../plink-ng/2.0/include
-PKG_LIBS += -L.. -l:plink2_includes.a
+PKG_LIBS += -L.. -lplink2_includes
 
 OBJECTS = RcppExports.o SAIGE_fitGLMM_fast.o getMem.o VCF.o BGEN.o PLINK.o PGEN.o SAIGE_test.o SPA_binary.o SPA.o SPA_survival.o UTIL.o Main.o test.o CCT.o Binary_HyperGeo.o Binary_ComputeExact.o Binary_global.o Binary_ComputeExactSKATO.o Binary_resampling.o Binary_Permu_SKAT.o ER_binary_func.o LDmat.o 
 

--- a/src/SAIGE_fitGLMM_fast.cpp
+++ b/src/SAIGE_fitGLMM_fast.cpp
@@ -12,6 +12,7 @@
 #include <ctime>// include this header for calculating execution time 
 #include <cassert>
 #include <boost/date_time.hpp> // for gettimeofday and timeval
+#include <oneapi/tbb/concurrent_vector.h>
 #include "getMem.hpp"
 using namespace Rcpp;
 using namespace std;


### PR DESCRIPTION
Conda on newer Macs uses clang instead of gcc. Clang is stricter and wouldn't compile the older version of tbb, so the tbb dependency is updated as well. It successfully compiles on linux (with gcc, standalone and Docker) and osx-arm64 (with clang).