### PR TITLE
RareEffect 1.5.2: fix missing-genotype handling and several correctness

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: SAIGE
 Type: Package
 Title: Efficiently controlling for case-control imbalance and sample relatedness in single-variant assoc tests (SAIGE) and controlling for sample relatedness in region-based assoc tests in large cohorts and biobanks (SAIGE-GENE+) 
-Version: 1.5.1
-Date: 2025-11-1
+Version: 1.5.2
+Date: 2026-06-25
 Author: Wei Zhou, Bram Gorissen, Zhangchen Zhao, Wenjian Bi, Seunggeun Lee, Cristen Willer
 Maintainer: SAIGE team <saige.genetics@gmail.com> 
 Description:an R package that implements the Scalable and Accurate Implementation of Generalized mixed model that uses the saddlepoint approximation (SPA)(mhof, J. P. , 1961; Kuonen, D. 1999; Dey, R. et.al 2017) and large scale optimization techniques to calibrate case-control ratios in logistic mixed model score tests (Chen, H. et al. 2016) in large PheWAS. It conducts both single-variant association tests and set-based tests for rare variants.  

--- a/R/Firth.R
+++ b/R/Firth.R
@@ -78,12 +78,12 @@ fast.logistf.fit.WithL2 <- function (x, y, weight = NULL, offset = NULL, firth =
   # Error catching (if chol(x) not positive definite)
   if(all(is.na(XX.covs))==T) {
     var <- XX.covs
-    list(beta = NA, var = var, pi = NA, hat.diag = NA,
+    list(beta = NA, var = NA, pi = NA, hat.diag = NA,
          iter = NA, evals = NA, conv = c(NA,
                                          NA, NA))
   } else {
     var <- XX.covs
-    list(beta = beta, var = var, pi = pi, hat.diag = h,
+    list(beta = beta, var = NA, pi = pi, hat.diag = h,
          iter = iter, evals = evals, conv = c(max(abs(U.star)),
                                               max(abs(delta))))
   }
@@ -135,7 +135,7 @@ fast.logistf.fit.WithL2.fast <- function (x, y, out.null.firth=NULL, weight = NU
   gconv <- control$gconv
   xconv <- control$xconv
 
-  re.out<-list(beta = NA, var = var, pi = NA, hat.diag = NA, iter = NA, evals = NA, conv = c(NA, NA, NA))
+  re.out<-list(beta = NA, var = NA, pi = NA, hat.diag = NA, iter = NA, evals = NA, conv = c(NA, NA, NA))
 
   # By SLEE, compute once...
   if(is.null(out.null.firth)){
@@ -201,7 +201,7 @@ fast.logistf.fit.WithL2.fast <- function (x, y, out.null.firth=NULL, weight = NU
   # Error catching (if chol(x) not positive definite)
   if(all(is.na(XX.covs))==F) {
 
-    re.out = list(beta = beta, var = var, pi = pi, hat.diag = h,
+    re.out = list(beta = beta, var = NA, pi = pi, hat.diag = h,
          iter = iter, evals = evals, conv = c(max(abs(U.star)),
                                               max(abs(delta))))
   }
@@ -233,7 +233,7 @@ fast.logistf.fit.WithL2.Sparse <- function (g, y, idx=NULL, init = NULL, out.nul
   gconv <- control$gconv
   xconv <- control$xconv
 
-  re.out<-list(beta = NA, var = var, pi = NA, hat.diag = NA, iter = NA, evals = NA, conv = c(NA, NA, NA))
+  re.out<-list(beta = NA, var = NA, pi = NA, hat.diag = NA, iter = NA, evals = NA, conv = c(NA, NA, NA))
 
   # By SLEE, compute once...
   if(is.null(out.null.firth)){
@@ -310,7 +310,7 @@ fast.logistf.fit.WithL2.Sparse <- function (g, y, idx=NULL, init = NULL, out.nul
   }
 
 
-    re.out = list(beta = beta, var = var, iter = iter, evals = evals, conv = c(max(abs(U.star.1)),
+    re.out = list(beta = beta, var = NA, iter = iter, evals = evals, conv = c(max(abs(U.star.1)),
                                               max(abs(delta))))
 
   return(re.out)
@@ -372,7 +372,7 @@ Run_Firth_With_L2<-function(G1, y, offset, l2.var, Is.Fast=TRUE, Is.Sparse=FALSE
                                   , l2.var.pos=2, control=fast.logistf.control(maxit=maxit))
 	}
 
-    if(out_f2$iter <= maxit){ #Use the original version when the second one didnot converge.
+    if(out_f2$iter < maxit){ #Use the L2-penalized fit only when it converged before hitting maxit; iter == maxit means it did not converge, so fall back to out_f1.
       re = out_f2$beta[2]
     }
   }
@@ -414,20 +414,5 @@ Run_Firth_MultiVar_Single<-function(G1.all, obj.null, y, offset1, nMarker, l2.va
 
   results<-cbind(out_single_beta, out_multi_beta)
   return(results)
-
-}
-
-
-Run_Existing_Approach<-function(G1.all, obj.null, y, offset1, nMarker, l2.var=NULL){
-
-  out_single_ext<-rep(0,nMarker)
-  for(j in 1:nMarker){
-
-    G1<-G1.all[,j]
-
-    #source("Firth.R")
-    re<-Run_Firth_With_L2(G1, y, offset1, l2.var)
-    out_single_beta[j]<-re
-  }
 
 }

--- a/R/RareEffect.R
+++ b/R/RareEffect.R
@@ -1,53 +1,57 @@
 # Read Group file and split variants by functional annotations
 read_groupfile <- function(groupfile_name, gene_name) {
-    groupfile <- file(groupfile_name, "r")
-    line <- 0
+    lines <- readLines(groupfile_name)
+
+    # Pre-filter to only the gene's lines via fixed-string startsWith
+    # (regex strsplit on every line is the dominant cost for large group files)
+    prefix_sp <- paste0(gene_name, " ")
+    prefix_tab <- paste0(gene_name, "\t")
+    gene_lines <- lines[startsWith(lines, prefix_sp) | startsWith(lines, prefix_tab)]
+
     var <- NULL
     anno <- NULL
-
-    while (TRUE) {
-        line <- line + 1
-        marker_group_line <- readLines(groupfile, n = 1)
-
-        if (length(marker_group_line) == 0) {
-            break
+    for (marker_group_line in gene_lines) {
+        marker_group_line_list <- strsplit(marker_group_line, split = "[ \t]+")[[1]]
+        if (length(marker_group_line_list) < 2) next
+        if (marker_group_line_list[2] == "var") {
+            var <- marker_group_line_list
+        } else {
+            anno <- marker_group_line_list
         }
-
-        marker_group_line_list <- strsplit(marker_group_line, split = c(" +", "\t"))[[1]]
-
-        if (marker_group_line_list[1] == gene_name) {
-            if (marker_group_line_list[2] == "var") {
-                var <- marker_group_line_list
-            } else {
-                anno <- marker_group_line_list
-            }
-        }
+        if (!is.null(var) && !is.null(anno)) break
     }
 
-    lof_idx <- which(anno == "lof")
-    mis_idx <- which(anno == "missense")
-    syn_idx <- which(anno == "synonymous")
-
-    lof_var <- var[lof_idx]
-    mis_var <- var[mis_idx]
-    syn_var <- var[syn_idx]
-
-    out <- list(lof_var, mis_var, syn_var)
-    close(groupfile)
-    return(out)
+    lof_var <- var[which(anno == "lof")]
+    mis_var <- var[which(anno == "missense")]
+    syn_var <- var[which(anno == "synonymous")]
+    list(lof_var, mis_var, syn_var)
 }
 
 read_matrix_by_one_marker <- function(objGeno, var_list, sampleID) {
     n_samples <- length(sampleID)
-    mat <- Matrix::Matrix(0, nrow = n_samples, ncol = 0, sparse = TRUE)
     if (length(var_list) == 0) {
-        print("No variants in the list")
-        return(mat)
+        mat <- Matrix::Matrix(0, nrow = n_samples, ncol = 0, sparse = TRUE)
+        message("No variants in the list")
+        return(list(mat, rep(FALSE, 0)))
     }
-    is_flipped <- rep(FALSE, length(var_list))
-    for (i in 1:length(var_list)) {
+    p <- length(var_list)
+    is_flipped <- rep(FALSE, p)
+    i_list <- vector("list", p)
+    x_list <- vector("list", p)
+    nz_counts <- integer(p)
+
+    # Precompute marker index in objGeno$markerInfo$ID once
+    idx_map <- match(var_list, objGeno$markerInfo$ID)
+    if (anyNA(idx_map)) {
+        missing_vars <- var_list[is.na(idx_map)]
+        stop(sprintf("Variants not found in objGeno$markerInfo$ID: %s%s",
+                     paste(head(missing_vars, 5), collapse = ", "),
+                     if (length(missing_vars) > 5) sprintf(" (+%d more)", length(missing_vars) - 5) else ""))
+    }
+
+    for (i in seq_along(var_list)) {
         t_GVec <- rep(0, n_samples)
-        idx <- which(var_list[i] == objGeno$markerInfo$ID)
+        idx <- idx_map[i]
         SAIGE::Unified_getOneMarker(t_genoType = objGeno$genoType,
             t_gIndex_prev = objGeno$markerInfo$genoIndex_prev[idx],
             t_gIndex = objGeno$markerInfo$genoIndex[idx],
@@ -68,20 +72,39 @@ read_matrix_by_one_marker <- function(objGeno, var_list, sampleID) {
             t_isImputation = FALSE
         )
 
-	    t_GVec[t_GVec < 0] <- 0     # Convert missing to zero
-        # If MAF > 0.5, flip allele
-        if (sum(t_GVec) > n_samples) {
-            t_GVec <- 2 - t_GVec
-            is_flipped[i] <- TRUE
-        }
-        t_GVec_sp <- as(t_GVec, "sparseVector")
-        t_GVec_sp_mat <- as(t_GVec_sp, "Matrix")
+        # Unified_getOneMarker returns missing genotypes as a large sentinel (~2^64), NOT -1.
+        # Treat anything outside the valid [0,2] dosage range as missing and impute to 0 BEFORE
+        # the allele-sum / flip decision; otherwise the sentinel overflows sum() and spuriously
+        # triggers a flip, which then counts the major allele and corrupts MAC.
+        miss <- which(t_GVec < 0 | t_GVec > 2)
+        if (length(miss) > 0) t_GVec[miss] <- 0
 
-        mat <- cbind(mat, t_GVec_sp_mat)
+        # positive entries are now the non-missing, non-zero genotypes
+        nz <- which(t_GVec > 0)
+        vals <- t_GVec[nz]
+        s <- sum(vals)
+        if (s > n_samples) {
+            # Major allele is ALT — flip to count the minor allele. Almost never hit for rare
+            # variants. Note: this densifies the column (most zeros become 2s).
+            t_GVec <- 2 - t_GVec
+            t_GVec[miss] <- 0     # keep imputed-missing at 0 (not 2) after the flip
+            is_flipped[i] <- TRUE
+            nz <- which(t_GVec > 0)
+            vals <- t_GVec[nz]
+        }
+        i_list[[i]] <- nz
+        x_list[[i]] <- vals
+        nz_counts[i] <- length(nz)
     }
 
-    colnames(mat) <- var_list
-    rownames(mat) <- sampleID
+    # Construct sparseMatrix from accumulated triplets in one call
+    mat <- Matrix::sparseMatrix(
+        i = unlist(i_list, use.names = FALSE),
+        j = rep.int(seq_len(p), nz_counts),
+        x = unlist(x_list, use.names = FALSE),
+        dims = c(n_samples, p),
+        dimnames = list(sampleID, var_list)
+    )
 
     return(list(mat, is_flipped))
 }
@@ -90,7 +113,7 @@ collapse_matrix <- function(objGeno, var_list, sampleID, modglmm, macThreshold =
     n_samples <- length(sampleID)
     mat <- Matrix::Matrix(0, nrow = n_samples, ncol = 0, sparse = TRUE)
     if (length(var_list) == 0) {
-        print("No variants in the list")
+        message("No variants in the list")
         return(list(mat, NULL))
     }
     tmp <- read_matrix_by_one_marker(objGeno, var_list, sampleID)
@@ -98,21 +121,28 @@ collapse_matrix <- function(objGeno, var_list, sampleID, modglmm, macThreshold =
     is_flipped <- tmp[[2]]
     flipped_var <- as.data.table(cbind(var_list, is_flipped))
     mat <- mat[which(rownames(mat) %in% modglmm$sampleID), , drop = FALSE]
-    MAF <- colSums(mat) / (2 * nrow(mat))
-    idx_rare <- which((MAF < 0.01) & (colSums(mat) >= macThreshold))
-    idx_UR <- which((MAF > 0) & (colSums(mat) < macThreshold))
-    # mat <- mat[, idx, drop = FALSE]
+    MAC <- colSums(mat)
+    MAF <- MAC / (2 * nrow(mat))
+    idx_rare <- which((MAF < 0.01) & (MAC >= macThreshold))
+    idx_UR <- which((MAF > 0) & (MAC < macThreshold))
     if (length(idx_rare) == 0 & length(idx_UR) == 0) {
-        print("No variants with MAF < 0.01 or MAF > 0.99")
-        mat <- mat[, idx, drop = FALSE]
-        return(mat, NULL)
+        message("No variants with MAF < 0.01 or MAC > 0")
+        empty_mat <- Matrix::Matrix(0, nrow = nrow(mat), ncol = 0, sparse = TRUE)
+        return(list(empty_mat, flipped_var))
     }
     mat_rare <- mat[, idx_rare, drop = FALSE]
-    mat_UR <- mat[, idx_UR, drop = FALSE]
-    UR_rowsum <- rowSums(mat_UR)
-    UR_rowsum[which(UR_rowsum > 1)] <- 1
-    mat_UR_collapsed <- cbind(mat_rare, UR_rowsum)
-    return(list(mat_UR_collapsed, flipped_var))
+    if (length(idx_UR) > 0) {
+        mat_UR <- mat[, idx_UR, drop = FALSE]
+        UR_rowsum <- rowSums(mat_UR)
+        UR_rowsum[which(UR_rowsum > 1)] <- 1
+        mat_out <- cbind(mat_rare, UR_rowsum)
+        colnames(mat_out)[ncol(mat_out)] <- "UR"   # sentinel name for the collapsed ultra-rare column
+    } else {
+        # No ultra-rare variants: do NOT append a degenerate all-zero UR column (it would
+        # otherwise surface as a meaningless *_UR row indistinguishable from a true 0 effect).
+        mat_out <- mat_rare
+    }
+    return(list(mat_out, flipped_var))
 }
 
 get_range <- function(v) {
@@ -124,8 +154,6 @@ get_range <- function(v) {
             pos <- as.numeric(str_split_fixed(v[[i]], ":", 4)[,2]) # Modified in 0.3
             sub_start_pos <- min(pos)
             sub_end_pos <- max(pos)
-            print(sub_start_pos)
-            print(sub_end_pos)
             if (start_pos > sub_start_pos) {
                 start_pos <- sub_start_pos
             }
@@ -150,10 +178,7 @@ calc_log_lik <- function(delta, S, UtY, Y_UUtY) {
     k <- length(S)
     n <- nrow(Y_UUtY)
 
-    log_lik1 <- 0
-    for (i in 1:k) {
-        log_lik1 <- log_lik1 + (UtY[i, ])^2 / (S[i] + delta)
-    }
+    log_lik1 <- sum(as.numeric(UtY)^2 / (S + delta))   # vectorized over the k singular directions
 
     log_lik2 <- 1 / delta * sum((Y_UUtY)^2)
 
@@ -163,49 +188,52 @@ calc_log_lik <- function(delta, S, UtY, Y_UUtY) {
     return(as.numeric(out))
 }
 
-calc_post_beta <- function(K, G, delta, S, UtY, U) {
-    K_sparse <- as(K, "dgCMatrix")
-    if (length(S) == 1) {
-        S <- as.matrix(S)
+calc_post_beta <- function(G, delta, S, UtY, U, Sigma = NULL) {
+    d_vec <- as.numeric(1 / (S + delta))
+    # U %*% diag(d_vec) %*% UtY == U %*% (d_vec * UtY); avoid forming the k x k diagonal and an extra matmul
+    UDUtY <- U %*% (d_vec * UtY)
+    if (is.null(Sigma)) {
+        out <- t(G) %*% UDUtY
+    } else {
+        K_sparse <- as(Sigma, "dgCMatrix")
+        out <- K_sparse %*% t(G) %*% UDUtY
     }
-
-    out <- K_sparse %*% t(G) %*% U %*% diag(1 / (S + delta)) %*% (UtY)
     return(out)
 }
 
 # Run FaST-LMM to obtain posterior beta
-fast_lmm <- function(G, Y) {
-    # if sum(G) == 0, let effect size = 0
-    print("Estimating beta using FaST-LMM")
+fast_lmm <- function(G, Y, Sigma = NULL) {
     G[is.na(G)] <- 0
-    GtG <- t(G) %*% G
-    if (sum(G, na.rm = T) == 0) {
-        return (list(as.matrix(0), 0, 1e6, GtG))
+    GtG <- crossprod(G)
+    if (sum(G, na.rm = TRUE) == 0) {
+        return(list(as.matrix(0), 0, 1e6, GtG))
     }
     Y <- as.matrix(Y)
-    K <- diag(1, nrow = ncol(G))
-    L <- chol(K)
-    W <- G %*% L
-    W_sparse <- as(W, "dgCMatrix")
-    svd_mat <- sparsesvd::sparsesvd(W_sparse)
 
+    # We need W with W W' = G Sigma G'. R's chol(Sigma) returns upper-tri R with R'R = Sigma,
+    # so (G R')(G R')' = G R' R G' = G Sigma G'  =>  W = G %*% t(chol(Sigma)).
+    if (is.null(Sigma)) {
+        W_sparse <- as(G, "dgCMatrix")
+    } else {
+        L <- chol(Sigma)
+        W_sparse <- as(G %*% t(L), "dgCMatrix")
+    }
+
+    svd_mat <- sparsesvd::sparsesvd(W_sparse)
     U <- svd_mat$u
     S <- (svd_mat$d)^2
-
     UtY <- t(U) %*% Y
-
-    # Y_UUtY = Y - UUtY
     Y_UUtY <- Y - U %*% UtY
 
     opt <- optim(par = 1, fn = calc_log_lik, S = S, UtY = UtY, Y_UUtY = Y_UUtY,
-                 method = c("Brent"), lower = 0, upper = 1e6, control = list(fnscale = -1))
-    opt_delta <- opt$par
+                 method = "Brent", lower = 1e-10, upper = 1e6,
+                 control = list(fnscale = -1))
 
-    tr_GtG <- sum(diag(GtG %*% K))
+    # tr(G Sigma G') = tr(G'G Sigma) = sum(GtG * Sigma) for symmetric GtG, Sigma (avoids the full matmul)
+    tr_GtG_Sigma <- if (is.null(Sigma)) sum(diag(GtG)) else sum(GtG * Sigma)
+    post_beta <- calc_post_beta(G, opt$par, S, UtY, U, Sigma = Sigma)
 
-    post_beta <- calc_post_beta(K, G, opt_delta, S, UtY, U)
-
-    return (list(post_beta, tr_GtG, opt_delta, GtG))
+    return(list(post_beta, tr_GtG_Sigma, opt$par, GtG))
 }
 
 
@@ -219,68 +247,61 @@ calc_gene_effect_size <- function(G, lof_ncol, post_beta, Y) {
     return(m1$coefficients[2])
 }
 
-mom_estimator_marginal <- function(G, y) {
+mom_estimator_marginal <- function(G, y, Sigma = NULL, GtG = NULL) {
     n <- length(y)
     G <- as(G, "dgCMatrix")
     G[is.na(G)] <- 0
-    # tr(G Sigma G^T G Sigma G^T) = sum((G Sigma G^T )^2) = sum(G^T G Sigma)^2
-    Sigma <- diag(1, nrow = ncol(G))
 
-    system.time({
-        t1 <- sum((crossprod(G) %*% Sigma)^2)
-    })
-    t2 <- sum(diag(crossprod(G) %*% Sigma))
-    A <- matrix(c(t1, t2, t2, n), ncol = 2)
-    c1 <- as.numeric(t(y) %*% G %*% Sigma %*% t(G) %*% y)
+    if (is.null(Sigma)) {
+        if (is.null(GtG)) GtG <- crossprod(G)   # reuse the GtG already formed in fast_lmm when available
+        t1 <- sum(GtG^2)                    # tr((GG')^2)
+        t2 <- sum(diag(GtG))                # tr(G'G) == sum(G^2)
+        Gty <- crossprod(G, y)
+        c1 <- as.numeric(sum(Gty^2))        # y'GG'y
+    } else {
+        GtG_Sigma <- crossprod(G) %*% Sigma
+        t1 <- sum(GtG_Sigma^2)
+        t2 <- sum(diag(GtG_Sigma))
+        c1 <- as.numeric(t(y) %*% G %*% Sigma %*% t(G) %*% y)
+    }
+
     c2 <- sum(y^2)
+    A <- matrix(c(t1, t2, t2, n), ncol = 2)
     b <- matrix(c(c1, c2), ncol = 1)
-    var_comp <- solve(A) %*% b
-    # print(var_comp)
-    # h2_mom_marginal <- var_comp[1, 1] / sum(var_comp)
-    return (var_comp)
+    return(solve(A, b))
 }
 
-mom_estimator_joint <- function(G1, G2, G3, y) {
+mom_estimator_joint <- function(G1, G2, G3, y,
+                                 Sigma1 = NULL, Sigma2 = NULL, Sigma3 = NULL) {
     n <- length(y)
+    G1 <- as(G1, "dgCMatrix"); G1[is.na(G1)] <- 0
+    G2 <- as(G2, "dgCMatrix"); G2[is.na(G2)] <- 0
+    G3 <- as(G3, "dgCMatrix"); G3[is.na(G3)] <- 0
 
-    G1 <- as(G1, "dgCMatrix")
-    G1[is.na(G1)] <- 0
-    G2 <- as(G2, "dgCMatrix")
-    G2[is.na(G2)] <- 0
-    G3 <- as(G3, "dgCMatrix")
-    G3[is.na(G3)] <- 0
-    Sigma1 <- diag(1, nrow = ncol(G1)) # L1 %*% t(L1)
-    Sigma2 <- diag(1, nrow = ncol(G2)) # L2 %*% t(L2)
-    Sigma3 <- diag(1, nrow = ncol(G3)) # L3 %*% t(L3)
+    # W_k with W_k W_k' = G_k Sigma_k G_k'  =>  W_k = G_k %*% t(chol(Sigma_k)) (R chol gives R'R = Sigma)
+    W1 <- if (is.null(Sigma1)) G1 else G1 %*% t(chol(Sigma1))
+    W2 <- if (is.null(Sigma2)) G2 else G2 %*% t(chol(Sigma2))
+    W3 <- if (is.null(Sigma3)) G3 else G3 %*% t(chol(Sigma3))
 
-    L1 <- chol(Sigma1)
-    L2 <- chol(Sigma2)
-    L3 <- chol(Sigma3)
+    t11 <- sum(crossprod(W1)^2)
+    t22 <- sum(crossprod(W2)^2)
+    t33 <- sum(crossprod(W3)^2)
+    t12 <- sum(crossprod(W1, W2)^2)
+    t13 <- sum(crossprod(W1, W3)^2)
+    t23 <- sum(crossprod(W2, W3)^2)
+    t14 <- sum(W1^2)
+    t24 <- sum(W2^2)
+    t34 <- sum(W3^2)
 
-    t11 <- sum((crossprod(G1) %*% Sigma1)^2)
-    t22 <- sum((crossprod(G2) %*% Sigma2)^2)
-    t33 <- sum((crossprod(G3) %*% Sigma3)^2)
+    A <- matrix(c(t11,t12,t13,t14, t12,t22,t23,t24,
+                  t13,t23,t33,t34, t14,t24,t34,n), ncol = 4)
 
-    t12 <- sum((t(G1 %*% L1) %*% (G2 %*% L2))^2)
-    t13 <- sum((t(G1 %*% L1) %*% (G3 %*% L3))^2)
-    t23 <- sum((t(G2 %*% L2) %*% (G3 %*% L3))^2)
+    c1 <- as.numeric(sum(crossprod(W1, y)^2))
+    c2 <- as.numeric(sum(crossprod(W2, y)^2))
+    c3 <- as.numeric(sum(crossprod(W3, y)^2))
+    b <- matrix(c(c1, c2, c3, sum(y^2)), ncol = 1)
 
-    t14 <- sum(diag(t(G1) %*% G1 %*% Sigma1))
-    t24 <- sum(diag(t(G2) %*% G2 %*% Sigma2))
-    t34 <- sum(diag(t(G3) %*% G3 %*% Sigma3))
-
-    A <- matrix(c(t11, t12, t13, t14, t12, t22, t23, t24, t13, t23, t33, t34, t14, t24, t34, n), ncol = 4)
-
-    c1 <- as.numeric(t(y) %*% G1 %*% Sigma1 %*% t(G1) %*% y)
-    c2 <- as.numeric(t(y) %*% G2 %*% Sigma2 %*% t(G2) %*% y)
-    c3 <- as.numeric(t(y) %*% G3 %*% Sigma3 %*% t(G3) %*% y)
-    c4 <- sum(y^2)
-    b <- matrix(c(c1, c2, c3, c4), ncol = 1)
-
-    var_comp <- solve(A) %*% b
-    # print(var_comp)
-    #  h2_mom_joint <- c(var_comp[1, 1], var_comp[2, 1], var_comp[3, 1]) / sum(var_comp)
-    return (var_comp)
+    return(solve(A, b))
 }
 
 # calculate_single_blup <- function(G, delta, Sigma, y) {
@@ -290,33 +311,39 @@ mom_estimator_joint <- function(G1, G2, G3, y) {
 #     return (beta)
 # }
 
-calculate_joint_blup <- function(G1, G2, G3, tau1, tau2, tau3, Sigma1, Sigma2, Sigma3, psi, y) {
+calculate_joint_blup <- function(G1, G2, G3, tau1, tau2, tau3, psi, y) {
     G1 <- as(G1, "dgCMatrix")
     G2 <- as(G2, "dgCMatrix")
     G3 <- as(G3, "dgCMatrix")
     G <- cbind(G1, G2, G3)
     G[is.na(G)] <- 0
+    p1 <- ncol(G1); p2 <- ncol(G2); p3 <- ncol(G3)
 
-    Sigma <- bdiag(tau1 * Sigma1, tau2 * Sigma2, tau3 * Sigma3)
-    beta <- solve(t(G) %*% G / psi + solve(Sigma)) %*% t(G) %*% y / psi
-    return (beta)
+    GtG <- crossprod(G)
+    Gty <- crossprod(G, y)
+
+    # (G'G / psi + Sigma^{-1}) where Sigma = bdiag(tau1*I, tau2*I, tau3*I)
+    C <- GtG / psi
+    inv_tau_diag <- c(rep(1/tau1, p1), rep(1/tau2, p2), rep(1/tau3, p3))
+    diag(C) <- diag(C) + inv_tau_diag
+
+    C_inv <- solve(C)
+    beta <- C_inv %*% (Gty / psi)
+    # Joint posterior (prediction error) variance: diag of the full joint precision inverse,
+    # which (unlike the per-group PEV) accounts for cross-group correlation among variants.
+    pev <- diag(C_inv)
+    return(list(beta = as.vector(beta), pev = as.numeric(pev)))
 }
 
-weight_cal <- function(beta_k, delta = 10^(-5), gamma = 2, q = 0, factor2 = 1, n_lof, n_mis, n_syn){
-	# delta=10^(-5); gamma=2; q=0
+weight_cal <- function(beta_k, delta = 10^(-5), gamma = 2, q = 0, factor2 = 1) {
 	p <- length(beta_k)
-    p1 <- n_lof
-    p2 <- n_mis
-    p3 <- n_syn
-	w_out = rep(0, p)
-	idx_null = NULL
-	idx<-which(abs(beta_k) <= delta)
+	w_out <- rep(0, p)
+	idx <- which(abs(beta_k) <= delta)
 	if(length(idx)> 0){
 		beta_k1<-beta_k[idx]
 		b_delta = abs(beta_k1/delta)^{gamma}
 		logw1 = (q-2) * log(delta) + (q-2)/gamma* log(1+ b_delta)
 		w_out[idx]<-exp(logw1 * factor2)
-		idx_null = idx
 	}
 	idx<-which(abs(beta_k) > delta)
 	if(length(idx)> 0){
@@ -334,46 +361,61 @@ weight_cal <- function(beta_k, delta = 10^(-5), gamma = 2, q = 0, factor2 = 1, n
 	return(list(w_out=w_out))
 }
 
-adaptive_ridge <- function(X, y, lambda, q = 0, delta = 1e-5, gamma = 2, max_iter = 100, tol = 0.01, sigma_sq = 1, n_lof, n_mis, n_syn) {
-    w <- rep(1, ncol(X))     # Initialize weights
-    beta <- rep(0, ncol(X))  # Initialize beta
-    beta_all<-NULL
-    w_all<-NULL
-    idx_set<-1:length(w)
+adaptive_ridge <- function(X, y, lambda, q = 0, delta = 1e-5, gamma = 2, max_iter = 100, tol = 0.01, sigma_sq = 1) {
+    w <- rep(1, ncol(X))
+    beta <- rep(0, ncol(X))
 
-    # save to reduce redundant computation
-    Xy = t(X) %*% y
-    XX = t(X) %*% X
+    Xy <- crossprod(X, y)
+    XX <- crossprod(X)
     for (k in 1:max_iter) {
-        W <- diag(w)
-        # using solve is better than calculating inverse matrix first...
-        beta_new <- solve(XX + lambda * W, Xy)  # Ridge regression for initial estimate
+        A <- XX
+        diag(A) <- diag(A) + lambda * w             # copy-on-write keeps XX intact
+        beta_new <- solve(A, Xy)
 
-        # Update weights
-        w_new_re <- weight_cal(beta_new, delta=delta, gamma=gamma, q=q, n_lof=n_lof, n_mis=n_mis, n_syn=n_syn)
-        w_new = w_new_re$w_out
+        w_new <- weight_cal(beta_new, delta = delta, gamma = gamma, q = q)$w_out
 
-        # print(sqrt(sum((beta_new - beta)^2)))
-        if (sqrt(sum((beta_new - beta)^2)) < sum(beta^2)*tol) {
-            # print(paste0("Converged at iteration: ", k))
+        # relative convergence: ||beta_new - beta|| < tol * ||beta||  (both are norms)
+        if (sqrt(sum((beta_new - beta)^2)) < sqrt(sum(beta^2)) * tol) {
             break
         }
 
         beta <- beta_new
         w <- w_new
-        w_all<-cbind(w_all, w)
-        beta_all<-cbind(beta_all, beta)
     }
 
     A <- XX
     diag(A) <- diag(A) + lambda * w
-    L <- chol(A)
-    A_inv <- chol2inv(L)
+    A_inv <- chol2inv(chol(A))
 
     cov_beta <- as.numeric(sigma_sq) * (A_inv %*% XX %*% A_inv)
     se_beta <- sqrt(diag(cov_beta))
 
-    list(beta = beta, weights = w, iterations = k, beta_all=beta_all, w_all=w_all, se_beta = se_beta)
+    list(beta = beta, weights = w, iterations = k, se_beta = se_beta)
+}
+
+# Helper: run FaST-LMM + MoM for a single annotation group
+estimate_group <- function(mat, y_vec, sigma_sq) {
+    result <- fast_lmm(G = mat, Y = y_vec)
+    post_beta <- result[[1]]
+    tr_GtG    <- result[[2]]
+    delta     <- result[[3]]
+    GtG       <- result[[4]]
+    tau       <- as.numeric(sigma_sq / delta)
+    tau_mom   <- mom_estimator_marginal(G = mat, y = y_vec, GtG = GtG)
+    list(post_beta = post_beta, tr_GtG = tr_GtG, delta = delta,
+         GtG = GtG, tau = tau, tau_mom = tau_mom)
+}
+
+# Helper: compute gene-level heritability for one group
+compute_h2 <- function(tau_adj, tr_GtG, sigma_sq, denom_extra) {
+    max(tau_adj * tr_GtG / (tau_adj * tr_GtG + sigma_sq * denom_extra), 0)
+}
+
+# Helper: compute PEV for one group
+compute_pev <- function(GtG, sigma_sq, tau_adj) {
+    GtG_scaled <- GtG / as.numeric(sigma_sq)
+    diag(GtG_scaled) <- diag(GtG_scaled) + 1 / tau_adj
+    diag(solve(GtG_scaled))
 }
 
 run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFile, bimFile, famFile, macThreshold, collapseLoF, collapsemis, collapsesyn, apply_AR, outputPrefix) {
@@ -386,12 +428,11 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
         modglmm$residuals <- sqrt(v) * (1 / (modglmm$fitted.values * (1 - modglmm$fitted.values)) * (modglmm$y - modglmm$fitted.values))
     }
     sigma_sq <- var(modglmm$residuals)
-    # n_samples <- length(modglmm$residuals)
 
     # Set PLINK object
-    bim <- fread(bimFile)
-    fam <- fread(famFile)
-    sampleID <- as.character(fam$V2)
+    # Only column 2 of fam (IID) is needed; bim is not used at R level
+    fam <- fread(famFile, select = 2, header = FALSE)
+    sampleID <- as.character(fam[[1]])
     n_samples <- length(sampleID)
 
     objGeno <- SAIGE::setGenoInput(bgenFile = "",
@@ -412,21 +453,21 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
             sampleInModel = sampleID
         )
 
-    print("Analysis started")
+    message("Analysis started")
 
     var_by_func_anno <- read_groupfile(groupFile, geneName)
 
     # LoF
     if (length(var_by_func_anno[[1]]) == 0) {
-        print("LoF variant does not exist.")
+        message("LoF variant does not exist.")
     }
     # missense
     if (length(var_by_func_anno[[2]]) == 0) {
-        print("missense variant does not exist.")
+        message("missense variant does not exist.")
     }
     # synonymous
     if (length(var_by_func_anno[[3]]) == 0) {
-        print("synonymous variant does not exist.")
+        message("synonymous variant does not exist.")
     }
 
     # Remove variants not in plink file
@@ -440,30 +481,44 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
         lof_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[1]], sampleID, modglmm, macThreshold = 0)
         lof_mat_collapsed <- lof_mat_collapsed_all[[1]]
         lof_flipped <- lof_mat_collapsed_all[[2]]
-        lof_mat_collapsed <- Matrix::Matrix(rowSums(lof_mat_collapsed), ncol = 1, sparse = TRUE, dimnames = list(rownames(lof_mat_collapsed), NULL))
+        lof_mat_collapsed <- Matrix::Matrix(rowSums(lof_mat_collapsed), ncol = 1, sparse = TRUE, dimnames = list(rownames(lof_mat_collapsed), "lof_UR"))
     } else {
         lof_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[1]], sampleID, modglmm, macThreshold)
         lof_mat_collapsed <- lof_mat_collapsed_all[[1]]
         lof_flipped <- lof_mat_collapsed_all[[2]]
     }
-    mis_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[2]], sampleID, modglmm, macThreshold)
-    mis_mat_collapsed <- mis_mat_collapsed_all[[1]]
-    mis_flipped <- mis_mat_collapsed_all[[2]]
+    if (collapsemis) {
+        mis_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[2]], sampleID, modglmm, macThreshold = 0)
+        mis_mat_collapsed <- mis_mat_collapsed_all[[1]]
+        mis_flipped <- mis_mat_collapsed_all[[2]]
+        mis_mat_collapsed <- Matrix::Matrix(rowSums(mis_mat_collapsed), ncol = 1, sparse = TRUE, dimnames = list(rownames(mis_mat_collapsed), "mis_UR"))
+    } else {
+        mis_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[2]], sampleID, modglmm, macThreshold)
+        mis_mat_collapsed <- mis_mat_collapsed_all[[1]]
+        mis_flipped <- mis_mat_collapsed_all[[2]]
+    }
 
-    syn_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[3]], sampleID, modglmm, macThreshold)
-    syn_mat_collapsed <- syn_mat_collapsed_all[[1]]
-    syn_flipped <- syn_mat_collapsed_all[[2]]
+    if (collapsesyn) {
+        syn_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[3]], sampleID, modglmm, macThreshold = 0)
+        syn_mat_collapsed <- syn_mat_collapsed_all[[1]]
+        syn_flipped <- syn_mat_collapsed_all[[2]]
+        syn_mat_collapsed <- Matrix::Matrix(rowSums(syn_mat_collapsed), ncol = 1, sparse = TRUE, dimnames = list(rownames(syn_mat_collapsed), "syn_UR"))
+    } else {
+        syn_mat_collapsed_all <- collapse_matrix(objGeno, var_by_func_anno[[3]], sampleID, modglmm, macThreshold)
+        syn_mat_collapsed <- syn_mat_collapsed_all[[1]]
+        syn_flipped <- syn_mat_collapsed_all[[2]]
+    }
 
-    # Set column name
-    if (ncol(lof_mat_collapsed) > 0) {
-        colnames(lof_mat_collapsed)[ncol(lof_mat_collapsed)] <- "lof_UR"
-    }
-    if (ncol(mis_mat_collapsed) > 0) {
-        colnames(mis_mat_collapsed)[ncol(mis_mat_collapsed)] <- "mis_UR"
-    }
-    if (ncol(syn_mat_collapsed) > 0) {
-        colnames(syn_mat_collapsed)[ncol(syn_mat_collapsed)] <- "syn_UR"
-    }
+    # Rename the collapsed ultra-rare sentinel column ("UR") to the group-specific label.
+    # collapse_matrix only emits this column when the group actually has ultra-rare variants, so
+    # groups without any ultra-rare variant produce NO *_UR row (avoids an ambiguous 0-effect row).
+    # (The collapse* = TRUE branches already named their single whole-group burden column directly.)
+    ur_idx <- which(colnames(lof_mat_collapsed) == "UR")
+    if (length(ur_idx) > 0) colnames(lof_mat_collapsed)[ur_idx] <- "lof_UR"
+    ur_idx <- which(colnames(mis_mat_collapsed) == "UR")
+    if (length(ur_idx) > 0) colnames(mis_mat_collapsed)[ur_idx] <- "mis_UR"
+    ur_idx <- which(colnames(syn_mat_collapsed) == "UR")
+    if (length(ur_idx) > 0) colnames(syn_mat_collapsed)[ur_idx] <- "syn_UR"
 
     # Make genotype matrix
     nonempty_mat <- list()
@@ -479,21 +534,17 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
     # print("Dimension of G")
     # print(dim(G))
 
-    # Obtain residual vector and genotype matrix with the same order
-    y_tilde <- cbind(modglmm$sampleID, modglmm$residuals)
-    y_tilde <- y_tilde[which(y_tilde[,1] %in% sampleID),]
-    # G <- as.matrix(G)
-    G_reordered <- G[match(y_tilde[,1], rownames(G)),]
+    # Obtain residual vector and genotype matrix with the same sample order
+    # Use index-based alignment instead of cbind (which coerces numeric to character)
+    common_samples <- intersect(modglmm$sampleID, rownames(G))
+    model_idx <- match(common_samples, modglmm$sampleID)
+    y_vec <- as.numeric(modglmm$residuals[model_idx])
+    G_reordered <- G[match(common_samples, rownames(G)), , drop = FALSE]
     if (traitType == "binary") {
-        vG_reordered <- as.vector(sqrt(v)) * G_reordered    # Sigma_e^(-1/2) G
+        v_ordered <- v[model_idx]
+        vG_reordered <- as.vector(sqrt(v_ordered)) * G_reordered    # Sigma_e^(-1/2) G
     }
     n_samples <- nrow(G_reordered)
-    # print("Dimension of G_reordered")
-    # print(dim(G_reordered))
-
-    post_beta_lof <- NULL
-    post_beta_mis <- NULL
-    post_beta_syn <- NULL
 
     # Define matrices by functional annotation
     if (lof_ncol == 0) {
@@ -526,42 +577,14 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
         }
     }
 
-    # Run FaST-LMM for each functional annotation (estimate marginal variance component tau)
-    if (lof_ncol > 0) {
-        fast_lmm_lof <- fast_lmm(G = lof_mat, Y = as.numeric(y_tilde[,2]))
-        post_beta_lof <- fast_lmm_lof[[1]]
-        tr_GtG_lof <- fast_lmm_lof[[2]]
-        delta_lof <- fast_lmm_lof[[3]]
-        GtG_lof <- fast_lmm_lof[[4]]
-        tau_lof <- as.numeric(sigma_sq / delta_lof)
-        tau_lof_mom_marginal <- mom_estimator_marginal(G = lof_mat, y = as.numeric(y_tilde[,2]))
-    } else {
-        tau_lof <- 0
-    }
+    # Run FaST-LMM + MoM for each functional annotation group
+    est_lof <- if (lof_ncol > 0) estimate_group(lof_mat, y_vec, sigma_sq) else NULL
+    est_mis <- if (mis_ncol > 0) estimate_group(mis_mat, y_vec, sigma_sq) else NULL
+    est_syn <- if (syn_ncol > 0) estimate_group(syn_mat, y_vec, sigma_sq) else NULL
 
-    if (mis_ncol > 0) {
-        fast_lmm_mis <- fast_lmm(G = mis_mat, Y = as.numeric(y_tilde[,2]))
-        post_beta_mis <- fast_lmm_mis[[1]]
-        tr_GtG_mis <- fast_lmm_mis[[2]]
-        delta_mis <- fast_lmm_mis[[3]]
-        GtG_mis <- fast_lmm_mis[[4]]
-        tau_mis <- as.numeric(sigma_sq / delta_mis)
-        tau_mis_mom_marginal <- mom_estimator_marginal(G = mis_mat, y = as.numeric(y_tilde[,2]))
-    } else {
-        tau_mis <- 0
-    }
-
-    if (syn_ncol > 0) {
-        fast_lmm_syn <- fast_lmm(G = syn_mat, Y = as.numeric(y_tilde[,2]))
-        post_beta_syn <- fast_lmm_syn[[1]]
-        tr_GtG_syn <- fast_lmm_syn[[2]]
-        delta_syn <- fast_lmm_syn[[3]]
-        GtG_syn <- fast_lmm_syn[[4]]
-        tau_syn <- as.numeric(sigma_sq / delta_syn)
-        tau_syn_mom_marginal <- mom_estimator_marginal(G = syn_mat, y = as.numeric(y_tilde[,2]))
-    } else {
-        tau_syn <- 0
-    }
+    tau_lof <- if (!is.null(est_lof)) est_lof$tau else 0
+    tau_mis <- if (!is.null(est_mis)) est_mis$tau else 0
+    tau_syn <- if (!is.null(est_syn)) est_syn$tau else 0
 
     # Estimate variance component tau jointly (MoM estimator), only if all groups are non-empty
     if ((lof_ncol > 0) & (mis_ncol > 0) & (syn_ncol > 0)) {
@@ -569,13 +592,26 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
             G1 = lof_mat,
             G2 = mis_mat,
             G3 = syn_mat,
-            y = as.numeric(y_tilde[,2])
+            y = y_vec
         )
 
         # Adjust variance component tau
-        tau_lof_adj <- tau_lof * tau_mom_joint[1] / tau_lof_mom_marginal[1]
-        tau_mis_adj <- tau_mis * tau_mom_joint[2] / tau_mis_mom_marginal[1]
-        tau_syn_adj <- tau_syn * tau_mom_joint[3] / tau_syn_mom_marginal[1]
+        # Only apply ratio correction when both marginal and joint MoM estimates are positive
+        if (est_lof$tau_mom[1] > 0 && tau_mom_joint[1] > 0) {
+            tau_lof_adj <- tau_lof * tau_mom_joint[1] / est_lof$tau_mom[1]
+        } else {
+            tau_lof_adj <- tau_lof
+        }
+        if (est_mis$tau_mom[1] > 0 && tau_mom_joint[2] > 0) {
+            tau_mis_adj <- tau_mis * tau_mom_joint[2] / est_mis$tau_mom[1]
+        } else {
+            tau_mis_adj <- tau_mis
+        }
+        if (est_syn$tau_mom[1] > 0 && tau_mom_joint[3] > 0) {
+            tau_syn_adj <- tau_syn * tau_mom_joint[3] / est_syn$tau_mom[1]
+        } else {
+            tau_syn_adj <- tau_syn
+        }
     } else {
         # Use marginal variance component tau if any group is empty
         tau_lof_adj <- tau_lof
@@ -583,141 +619,112 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
         tau_syn_adj <- tau_syn
     }
 
-    # Estimate gene-level heritability
-    if (traitType == "binary") {
-        # For binary
-        if (lof_ncol > 0) {
-            h2_lof_adj <- max(tau_lof_adj * tr_GtG_lof / (tau_lof_adj * tr_GtG_lof + sigma_sq * sum(1/v)), 0)
-        } else {
-            h2_lof_adj <- 0
-        }
-
-        if (mis_ncol > 0) {
-            h2_mis_adj <- max(tau_mis_adj * tr_GtG_mis / (tau_mis_adj * tr_GtG_mis + sigma_sq * sum(1/v)), 0)
-        } else {
-            h2_mis_adj <- 0
-        }
-
-        if (syn_ncol > 0) {
-            h2_syn_adj <- max(tau_syn_adj * tr_GtG_syn / (tau_syn_adj * tr_GtG_syn + sigma_sq * sum(1/v)), 0)
-        } else {
-            h2_syn_adj <- 0
-        }
-    } else {
-        # For quantitative
-        if (lof_ncol > 0) {
-            h2_lof_adj <- max(tau_lof_adj * tr_GtG_lof / (tau_lof_adj * tr_GtG_lof + sigma_sq * n_samples), 0)
-        } else {
-            h2_lof_adj <- 0
-        }
-
-        if (mis_ncol > 0) {
-            h2_mis_adj <- max(tau_mis_adj * tr_GtG_mis / (tau_mis_adj * tr_GtG_mis + sigma_sq * n_samples), 0)
-        } else {
-            h2_mis_adj <- 0
-        }
-
-        if (syn_ncol > 0) {
-            h2_syn_adj <- max(tau_syn_adj * tr_GtG_syn / (tau_syn_adj * tr_GtG_syn + sigma_sq * n_samples), 0)
-        } else {
-            h2_syn_adj <- 0
-        }
-    }
+    # Estimate gene-level heritability.
+    # Heritability is defined on the working-residual (tilde-y) scale (paper eqs. for h2_j):
+    #   h2 = tr(G Sigma G') / (tr(G Sigma G') + psi * sum(1/v_i))   [binary]
+    # The numerator tr(G Sigma G') uses the ORIGINAL genotype G. For binary traits the group
+    # matrices fed to fast_lmm are the standardized sqrt(v)*G, whose tr is v-weighted (z-scale),
+    # which would mix scales with the tilde-y-scale denominator psi*sum(1/v). So recompute the
+    # unweighted trace from G_reordered. (For quantitative this equals est$tr_GtG, i.e. no change.)
+    h2_denom <- if (traitType == "binary") sum(1/v_ordered) else n_samples
+    tr_lof_h2 <- if (lof_ncol > 0) sum(G_reordered[, 1:lof_ncol, drop = FALSE]^2) else 0
+    tr_mis_h2 <- if (mis_ncol > 0) sum(G_reordered[, (lof_ncol + 1):(lof_ncol + mis_ncol), drop = FALSE]^2) else 0
+    tr_syn_h2 <- if (syn_ncol > 0) sum(G_reordered[, (lof_ncol + mis_ncol + 1):(lof_ncol + mis_ncol + syn_ncol), drop = FALSE]^2) else 0
+    h2_lof_adj <- if (!is.null(est_lof)) compute_h2(tau_lof_adj, tr_lof_h2, sigma_sq, h2_denom) else 0
+    h2_mis_adj <- if (!is.null(est_mis)) compute_h2(tau_mis_adj, tr_mis_h2, sigma_sq, h2_denom) else 0
+    h2_syn_adj <- if (!is.null(est_syn)) compute_h2(tau_syn_adj, tr_syn_h2, sigma_sq, h2_denom) else 0
 
     # Obtain effect size jointly if all groups are non-empty
-    if ((tau_lof_adj > 0) & (tau_mis_adj > 0) & (tau_syn_adj > 0)) {
-        post_beta <- calculate_joint_blup(
-            G1 = lof_mat,
-            G2 = mis_mat,
-            G3 = syn_mat,
-            tau1 = tau_lof_adj,
-            tau2 = tau_mis_adj,
-            tau3 = tau_syn_adj,
-            Sigma1 = diag(1, ncol(lof_mat)),
-            Sigma2 = diag(1, ncol(mis_mat)),
-            Sigma3 = diag(1, ncol(syn_mat)),
-            psi = as.numeric(sigma_sq),
-            y = as.numeric(y_tilde[,2])
+    used_joint <- (tau_lof_adj > 0) & (tau_mis_adj > 0) & (tau_syn_adj > 0)
+    joint_pev <- NULL
+    if (used_joint) {
+        blup <- calculate_joint_blup(
+            G1 = lof_mat, G2 = mis_mat, G3 = syn_mat,
+            tau1 = tau_lof_adj, tau2 = tau_mis_adj, tau3 = tau_syn_adj,
+            psi = as.numeric(sigma_sq), y = y_vec
         )
+        post_beta <- blup$beta
+        joint_pev <- blup$pev
     } else {
         # If not, calculate beta marginally
-        post_beta <- as.vector(rbind(post_beta_lof, post_beta_mis, post_beta_syn))
+        post_beta <- as.vector(rbind(
+            if (!is.null(est_lof)) est_lof$post_beta else NULL,
+            if (!is.null(est_mis)) est_mis$post_beta else NULL,
+            if (!is.null(est_syn)) est_syn$post_beta else NULL
+        ))
     }
 
     post_beta <- as.vector(post_beta)
 
-    if (apply_AR == TRUE) {
+    if (isTRUE(apply_AR)) {
         tau1 = tau_lof_adj
         tau2 = tau_mis_adj
         tau3 = tau_syn_adj
-        Sigma1 = rep(1, ncol(lof_mat))
-        Sigma2 = rep(1, ncol(mis_mat))
-        Sigma3 = rep(1, ncol(syn_mat))
+        # Use *_ncol (0 for empty groups) instead of ncol(*_mat); an empty group's mat is NULL,
+        # and ncol(NULL) is NULL, which would break rep()/c() below.
+        Sigma1 = rep(1, lof_ncol)
+        Sigma2 = rep(1, mis_ncol)
+        Sigma3 = rep(1, syn_ncol)
         psi = as.numeric(sigma_sq)
         lambda <- psi / c(tau1 * Sigma1, tau2 * Sigma2, tau3 * Sigma3)
-        result_AR <- adaptive_ridge(G_reordered, as.numeric(y_tilde[,2]), lambda, q = 0, delta = 1e-5, gamma = 2, max_iter = 5, tol = 0.01, sigma_sq = sigma_sq, n_lof = lof_ncol, n_mis = mis_ncol, n_syn = syn_ncol)
+        # Use the same working design as the variance-component / BLUP step:
+        # standardized sqrt(v) * G for binary, raw G for quantitative.
+        design_AR <- if (traitType == "binary") vG_reordered else G_reordered
+        result_AR <- adaptive_ridge(design_AR, y_vec, lambda, q = 0, delta = 1e-5, gamma = 2, max_iter = 5, tol = 0.01, sigma_sq = sigma_sq)
         post_beta <- as.vector(result_AR$beta)
-        se_beta <- (as.vector(result_AR$se_beta))
-    }
-
-    if (apply_AR == FALSE) {
-        # Obtain prediction error variance (PEV)
-        if (lof_ncol > 0) {
-            # diag(GtG_lof) <- diag(GtG_lof) + as.numeric(sigma_sq) / tau_lof_adj
-            GtG_lof <- GtG_lof / as.numeric(sigma_sq)
-            diag(GtG_lof) <- diag(GtG_lof) + 1 / tau_lof_adj
-            PEV_lof <- diag(solve(GtG_lof))
-        } else {
-            PEV_lof <- NULL
-        }
-
-        if (mis_ncol > 0) {
-            # diag(GtG_mis) <- diag(GtG_mis) + as.numeric(sigma_sq) / tau_mis_adj
-            GtG_mis <- GtG_mis / as.numeric(sigma_sq)
-            diag(GtG_mis) <- diag(GtG_mis) + 1 / tau_mis_adj
-            PEV_mis <- diag(solve(GtG_mis))
-        } else {
-            PEV_mis <- NULL
-        }
-
-        if (syn_ncol > 0) {
-            # diag(GtG_syn) <- diag(GtG_syn) + as.numeric(sigma_sq) / tau_syn_adj
-            GtG_syn <- GtG_syn / as.numeric(sigma_sq)
-            diag(GtG_syn) <- diag(GtG_syn) + 1 / tau_syn_adj
-            PEV_syn <- diag(solve(GtG_syn))
-        } else {
-            PEV_syn <- NULL
-        }
-
-        PEV <- abs(c(PEV_lof, PEV_mis, PEV_syn))
-    } else {
+        se_beta <- as.vector(result_AR$se_beta)
         PEV <- se_beta^2
+    } else if (used_joint) {
+        # post_beta came from the joint BLUP -> use the matching joint PEV (accounts for
+        # cross-group covariance, unlike the per-group block-diagonal compute_pev()).
+        PEV <- abs(joint_pev)
+    } else {
+        # Marginal (per-group, block-diagonal) prediction error variance (PEV)
+        PEV_lof <- if (!is.null(est_lof)) compute_pev(est_lof$GtG, sigma_sq, tau_lof_adj) else NULL
+        PEV_mis <- if (!is.null(est_mis)) compute_pev(est_mis$GtG, sigma_sq, tau_mis_adj) else NULL
+        PEV_syn <- if (!is.null(est_syn)) compute_pev(est_syn$GtG, sigma_sq, tau_syn_adj) else NULL
+        PEV <- abs(c(PEV_lof, PEV_mis, PEV_syn))
     }
 
     # Apply Firth bias correction for binary phenotype
     if (traitType == "binary") {
-        y_binary <- cbind(modglmm$sampleID, modglmm$y)
-        offset1 <- modglmm$linear.predictors - modglmm$coefficients[1]
-        l2.var = 1
-        maxit = 50
+        # Align y and offset to G_reordered sample order
+        firth_model_idx <- match(rownames(G_reordered), modglmm$sampleID)
+        y_binary_vec <- modglmm$y[firth_model_idx]
+        offset1 <- modglmm$linear.predictors[firth_model_idx] - modglmm$coefficients[1]
+
+        out_single_wL2_lof_sparse <- numeric(0)
+        out_single_wL2_mis_sparse <- numeric(0)
+        out_single_wL2_syn_sparse <- numeric(0)
 
         # LoF
-        G.lof.sp <- as(G_reordered[,c(1:lof_ncol), drop = F], "sparseMatrix")
-        nMarker.lof <- ncol(G.lof.sp)
-        out_single_wL2_lof_sparse <- Run_Firth_MultiVar_Single(G.lof.sp, modglmm$obj.noK, as.numeric(y_binary[,2]), offset1, nMarker.lof, l2.var=1/(2*tau_lof_adj), Is.Fast=FALSE, Is.Sparse=TRUE)[,2]
-        # print(out_single_wL2_lof_sparse)
+        if (lof_ncol > 0) {
+            G.lof.sp <- as(G_reordered[, 1:lof_ncol, drop = F], "sparseMatrix")
+            out_single_wL2_lof_sparse <- Run_Firth_MultiVar_Single(
+                G.lof.sp, modglmm$obj.noK, y_binary_vec, offset1,
+                lof_ncol, l2.var = 1/(2*tau_lof_adj),
+                Is.Fast = FALSE, Is.Sparse = TRUE)[, 2]
+        }
 
         # mis
-        G.mis.sp <- as(G_reordered[,c((lof_ncol + 1):(lof_ncol + mis_ncol)), drop = F], "sparseMatrix")
-        nMarker.mis <- ncol(G.mis.sp)
-        out_single_wL2_mis_sparse <- Run_Firth_MultiVar_Single(G.mis.sp, modglmm$obj.noK, as.numeric(y_binary[,2]), offset1, nMarker.mis, l2.var=1/(2*tau_mis_adj), Is.Fast=FALSE, Is.Sparse=TRUE)[,2]
-        # print(out_single_wL2_mis_sparse)
+        if (mis_ncol > 0) {
+            mis_cols <- (lof_ncol + 1):(lof_ncol + mis_ncol)
+            G.mis.sp <- as(G_reordered[, mis_cols, drop = F], "sparseMatrix")
+            out_single_wL2_mis_sparse <- Run_Firth_MultiVar_Single(
+                G.mis.sp, modglmm$obj.noK, y_binary_vec, offset1,
+                mis_ncol, l2.var = 1/(2*tau_mis_adj),
+                Is.Fast = FALSE, Is.Sparse = TRUE)[, 2]
+        }
 
         # syn
-        G.syn.sp <- as(G_reordered[,c((lof_ncol + mis_ncol + 1):(lof_ncol + mis_ncol + syn_ncol)), drop = F], "sparseMatrix")
-        nMarker.syn <- ncol(G.syn.sp)
-        out_single_wL2_syn_sparse <- Run_Firth_MultiVar_Single(G.syn.sp, modglmm$obj.noK, as.numeric(y_binary[,2]), offset1, nMarker.syn, l2.var=1/(2*tau_syn_adj), Is.Fast=FALSE, Is.Sparse=TRUE)[,2]
-        # print(out_single_wL2_syn_sparse)
+        if (syn_ncol > 0) {
+            syn_cols <- (lof_ncol + mis_ncol + 1):(lof_ncol + mis_ncol + syn_ncol)
+            G.syn.sp <- as(G_reordered[, syn_cols, drop = F], "sparseMatrix")
+            out_single_wL2_syn_sparse <- Run_Firth_MultiVar_Single(
+                G.syn.sp, modglmm$obj.noK, y_binary_vec, offset1,
+                syn_ncol, l2.var = 1/(2*tau_syn_adj),
+                Is.Fast = FALSE, Is.Sparse = TRUE)[, 2]
+        }
 
         beta_firth <- c(out_single_wL2_lof_sparse, out_single_wL2_mis_sparse, out_single_wL2_syn_sparse)
         effect <- ifelse(abs(post_beta) < log(2), post_beta, beta_firth)
@@ -729,38 +736,92 @@ run_RareEffect <- function(rdaFile, chrom, geneName, groupFile, traitType, bedFi
     # output related to single-variant effect size
     variant <- colnames(G)
 
+    # Build annotation and is_UR vectors
+    anno_vec <- c(rep("lof", lof_ncol), rep("missense", mis_ncol), rep("synonymous", syn_ncol))
+    is_UR <- grepl("_UR$", variant)
+
+    # Look up POS and alleles from the PLINK bim (authoritative), rather than parsing them out
+    # of the variant ID (IDs may be rs IDs that carry no allele info). With AlleleOrder =
+    # "alt-first" the bim's first allele column (5) is ALT = the effect allele = Allele2, and the
+    # second (6) is REF = Allele1; this matches how the genotype dosage / BETA / AF are coded.
+    # *_UR collapse labels (and any ID absent from the bim) do not match and become NA.
+    bim_info <- data.table::fread(bimFile, header = FALSE, select = c(2, 4, 5, 6),
+                                  col.names = c("ID", "POS", "ALT", "REF"))
+    bidx <- match(variant, bim_info$ID)
+    pos_vec <- bim_info$POS[bidx]
+    ref_vec <- bim_info$REF[bidx]   # Allele1 (REF / bim A2)
+    alt_vec <- bim_info$ALT[bidx]   # Allele2 (ALT / bim A1, effect allele)
+
+    # is_flipped per variant (internally recoded to the minor allele; track which were flipped)
+    flipped_var_all <- rbind(lof_flipped, mis_flipped, syn_flipped)
+    is_flipped_vec <- variant %in% flipped_var_all[is_flipped == TRUE, ]$var_list
+
+    # Allele count/frequency on the ALT allele (= Allele2 = effect allele).
+    # colSums(G_reordered) counts the internally-recoded minor allele, so for flipped
+    # variants the ALT count is (2N - minor count).
+    minor_AC <- as.numeric(colSums(G_reordered))
+    AC_Allele2 <- minor_AC
+    AC_Allele2[is_flipped_vec] <- 2 * n_samples - minor_AC[is_flipped_vec]
+    AF_Allele2 <- AC_Allele2 / (2 * n_samples)
+    AC_Allele2[is_UR] <- NA      # UR rows are collapsed indicators, not single variants
+    AF_Allele2[is_UR] <- NA
+
+    SE <- sqrt(PEV)
+
+    # Determine sign of gene-level effect from the reported (Firth-corrected) effect sizes,
+    # weighted by allele count (proportional to MAF): sgn(sum_j beta_j * MAF_j).
     if (lof_ncol == 1) {
-        sgn <- sign(post_beta[1])
+        sgn <- sign(effect[1])
     } else if (lof_ncol == 0) {
-        print("LoF variant does not exist, so the sign of the effect size is calculated by the sign of other groups.")
-        MAC <- colSums(G_reordered)
-        sgn <- sign(sum(MAC * post_beta))
+        message("LoF variant does not exist, so the sign of the effect size is calculated by the sign of other groups.")
+        MAC_sign <- colSums(G_reordered)
+        sgn <- sign(sum(MAC_sign * effect))
     } else {
-        MAC <- colSums(G_reordered[,c(1:(lof_ncol)), drop = F])
-        sgn <- sign(sum(MAC * post_beta[c(1:(lof_ncol))]))
+        MAC_sign <- colSums(G_reordered[,c(1:(lof_ncol)), drop = F])
+        sgn <- sign(sum(MAC_sign * effect[c(1:(lof_ncol))]))
     }
 
+    # Build effect output data.frame (SAIGE-style single-variant columns)
+    # BETA is reported per ALT (Allele2 / effect) allele; internal estimates are on the minor
+    # allele (the genotype is recoded to minor for accurate estimation), so negate the flipped
+    # ones to express everything on the ref/alt convention used in the summary output.
+    beta_alt <- as.numeric(effect)
+    beta_alt[is_flipped_vec] <- -beta_alt[is_flipped_vec]
+
+    effect_out <- data.frame(
+        gene = geneName,
+        CHR = chrom,
+        POS = pos_vec,
+        MarkerID = variant,
+        Allele1 = ref_vec,
+        Allele2 = alt_vec,
+        annotation = anno_vec,
+        is_UR = is_UR,
+        AC_Allele2 = AC_Allele2,
+        AF_Allele2 = AF_Allele2,
+        BETA = beta_alt,
+        SE = SE,
+        stringsAsFactors = FALSE
+    )
+
+    # Build h2 output data.frame (vertical format); group labels match effect_out$annotation
     h2_all <- sum(h2_lof_adj, h2_mis_adj, h2_syn_adj) * sgn
-    h2 <- c(h2_lof_adj, h2_mis_adj, h2_syn_adj, h2_all)
-    group <- c("LoF", "mis", "syn", "all")
-
-    effect_out <- as.data.frame(cbind(variant, effect, PEV))
-    effect_out$effect <- as.numeric(effect_out$effect)
-    effect_out$PEV <- as.numeric(effect_out$PEV)
-    h2_out <- rbind(group, h2)
-
-    # Find flipped var and change the sign of the effect size
-    flipped_var <- rbind(lof_flipped, mis_flipped, syn_flipped)
-    flipped_var <- flipped_var[is_flipped == TRUE,]$var_list
-    effect_out[which(effect_out$variant %in% flipped_var),]$effect <- -effect_out[which(effect_out$variant %in% flipped_var),]$effect
+    h2_out <- data.frame(
+        gene = geneName,
+        CHR = chrom,
+        group = c("lof", "missense", "synonymous", "all"),
+        h2 = c(h2_lof_adj, h2_mis_adj, h2_syn_adj, abs(h2_all)),
+        h2_signed = c(h2_lof_adj * sgn, h2_mis_adj * sgn, h2_syn_adj * sgn, h2_all),
+        tau_adj = c(tau_lof_adj, tau_mis_adj, tau_syn_adj, NA),
+        n_variants = c(lof_ncol, mis_ncol, syn_ncol, lof_ncol + mis_ncol + syn_ncol),
+        stringsAsFactors = FALSE
+    )
 
     effect_outname <- paste0(outputPrefix, "_effect.txt")
     h2_outname <- paste0(outputPrefix, "_h2.txt")
 
-    # print(effect_out)
-    # print(h2_out)
-    write.table(effect_out, effect_outname, row.names=F, quote=F)
-    write.table(h2_out, h2_outname, row.names=F, col.names=F, quote=F)
+    write.table(effect_out, effect_outname, row.names = FALSE, quote = FALSE, sep = "\t")
+    write.table(h2_out, h2_outname, row.names = FALSE, quote = FALSE, sep = "\t")
 
-    print("Analysis completed.")
+    message("Analysis completed.")
 }

--- a/extdata/calculate_RareEffect_PRS.R
+++ b/extdata/calculate_RareEffect_PRS.R
@@ -20,8 +20,8 @@ option_list <- list(
         help="Path to group file (containing functional annotation of variants)"),
     make_option(c("--geneName"), type="character", default="",
         help="Gene name to analyze"),
-    make_option(c("--variantListFile"), type="character", default="",
-        help="Path to file containing list of variants to exclude (non-ultra-rare variants)"),
+    make_option(c("--commonVariantsToExclude"), type="character", default="",
+        help="Path to file containing list of common variant IDs to exclude from PRS calculation (one variant ID per line)"),
     make_option(c("--outputPrefix"), type="character", default="",
         help="Path to save output (without extension and gene name)")
 )
@@ -31,7 +31,23 @@ parser <- OptionParser(usage="%prog [options]", option_list=option_list)
 args <- parse_args(parser, positional_arguments = FALSE)
 print(args)
 
-## Assign varibles
+## Validate required inputs
+required_args <- c("effectFile", "bedFile", "bimFile", "famFile", "groupFile", "geneName", "outputPrefix")
+for (arg_name in required_args) {
+    if (args[[arg_name]] == "") {
+        stop(paste0("--", arg_name, " is required but not provided."))
+    }
+}
+if (!file.exists(args$effectFile)) stop(paste0("Effect file not found: ", args$effectFile))
+if (!file.exists(args$bedFile)) stop(paste0("Bed file not found: ", args$bedFile))
+if (!file.exists(args$bimFile)) stop(paste0("Bim file not found: ", args$bimFile))
+if (!file.exists(args$famFile)) stop(paste0("Fam file not found: ", args$famFile))
+if (!file.exists(args$groupFile)) stop(paste0("Group file not found: ", args$groupFile))
+if (args$commonVariantsToExclude != "" && !file.exists(args$commonVariantsToExclude)) {
+    stop(paste0("Common-variant exclusion file not found: ", args$commonVariantsToExclude))
+}
+
+## Assign variables
 bedFile <- args$bedFile
 bimFile <- args$bimFile
 famFile <- args$famFile
@@ -66,7 +82,16 @@ objGeno <- SAIGE::setGenoInput(bgenFile = "",
         sampleInModel = sampleID
     )
 
+## Read effect file
 effect <- fread(effectFile)
+if (!all(c("MarkerID", "BETA") %in% colnames(effect))) {
+    stop("Effect file must contain 'MarkerID' and 'BETA' columns (SAIGE-style RareEffect output).")
+}
+# Allele convention: BETA is the effect of the ALT (Allele2) allele. Below, collapse_matrix
+# recodes each test variant to the TEST-set minor allele and returns the per-variant test flip
+# status. We align BETA to the allele the test genotype actually counts using that TEST-set flip
+# (see map_effects), so allele matching is correct even when a variant's minor allele differs
+# between the training and test cohorts. (Hence we do NOT pre-flip by any training flip here.)
 
 # LoF
 if (length(var_by_func_anno[[1]]) == 0) {
@@ -102,77 +127,93 @@ syn_flipped <- syn_mat_collapsed_all[[2]]
 print("Genotype matrix is loaded.")
 
 # Remove common variants
-if (args$variantListFile == "") {
-    print("No variant list file is provided.")
+if (args$commonVariantsToExclude == "") {
+    print("No common variant exclusion file is provided.")
 } else {
-    var_list <- fread(args$variantListFile)
+    var_list <- fread(args$commonVariantsToExclude, header = FALSE)
     common_var <- var_list$V1
-    lof_mat_collapsed <- lof_mat_collapsed[!which(colnames(lof_mat_collapsed) %in% common_var),]
-    mis_mat_collapsed <- mis_mat_collapsed[!which(colnames(mis_mat_collapsed) %in% common_var),]
-    syn_mat_collapsed <- syn_mat_collapsed[!which(colnames(syn_mat_collapsed) %in% common_var),]
-    print("Common variants are removed.")
+    lof_mat_collapsed <- lof_mat_collapsed[, !colnames(lof_mat_collapsed) %in% common_var, drop = FALSE]
+    mis_mat_collapsed <- mis_mat_collapsed[, !colnames(mis_mat_collapsed) %in% common_var, drop = FALSE]
+    syn_mat_collapsed <- syn_mat_collapsed[, !colnames(syn_mat_collapsed) %in% common_var, drop = FALSE]
+    print(paste0("Common variants removed. Remaining columns - lof: ", ncol(lof_mat_collapsed),
+                 ", mis: ", ncol(mis_mat_collapsed), ", syn: ", ncol(syn_mat_collapsed)))
+}
+
+## Helper: map effect sizes from the effect file to genotype matrix columns.
+## - Individual (rare) variants present in the effect file carry their own ALT-allele BETA,
+##   aligned to the allele the TEST genotype counts via the test-set flip (negate when the test
+##   genotype counts REF, i.e. ALT was major in the test set).
+## - Variants absent from the effect file are ultra-rare; they inherit the collapsed UR effect,
+##   which is defined on the minor allele (= what the genotype counts for ultra-rare variants),
+##   so it is applied as-is with no flip alignment.
+map_effects <- function(mat, effect_df, ur_label, flipped_df = NULL) {
+    nc <- ncol(mat)
+    if (nc == 0) {
+        return(numeric(0))
+    }
+
+    # UR effect (per minor allele); default 0 if not in effect file
+    ur_idx <- which(effect_df$MarkerID == ur_label)
+    ur_effect <- if (length(ur_idx) > 0) effect_df$BETA[ur_idx][1] else 0
+
+    # Initialize all positions with the UR effect (applied as-is on the minor allele)
+    eff_vec <- rep(ur_effect, nc)
+
+    # Test-set flip lookup: TRUE => test genotype counts REF (ALT was major in the test set)
+    flip_lookup <- NULL
+    if (!is.null(flipped_df) && nrow(flipped_df) > 0) {
+        flip_lookup <- setNames(as.logical(flipped_df$is_flipped), as.character(flipped_df$var_list))
+    }
+
+    # Overwrite with individual variant effects (ALT-allele BETA aligned to test counted allele)
+    cnames <- colnames(mat)
+    for (i in seq_len(nc)) {
+        idx <- which(effect_df$MarkerID == cnames[i])
+        if (length(idx) > 0) {
+            b <- effect_df$BETA[idx][1]
+            tf <- if (!is.null(flip_lookup)) flip_lookup[[cnames[i]]] else NULL
+            if (isTRUE(tf)) b <- -b   # test genotype counts REF -> effect of REF is -BETA(ALT)
+            eff_vec[i] <- b
+        }
+    }
+    return(eff_vec)
 }
 
 # Read effect size
 effect <- as.data.frame(effect)
 
-## LoF
-if (length(which(effect$variant == "lof_UR")) == 0) {
-    effect_lof_UR <- 0
-} else {
-    effect_lof_UR <- effect[which(effect$variant == "lof_UR"), ]$effect
-}
-
-effect_lof <- rep(effect_lof_UR, ncol(lof_mat_collapsed))
-
-for (i in 1:(ncol(lof_mat_collapsed) - 1)) {
-    if (length(which(effect$variant == colnames(lof_mat_collapsed)[i])) != 0) {
-        effect_lof[i] <- effect[which(effect$variant == colnames(lof_mat_collapsed)[i]), ]$effect
-    }
-}
-
-## mis
-if (length(which(effect$variant == "mis_UR")) == 0) {
-    effect_mis_UR <- 0
-} else {
-    effect_mis_UR <- effect[which(effect$variant == "mis_UR"), ]$effect
-}
-
-effect_mis <- rep(effect_mis_UR, ncol(mis_mat_collapsed))
-
-for (i in 1:(ncol(mis_mat_collapsed) - 1)) {
-    if (length(which(effect$variant == colnames(mis_mat_collapsed)[i])) != 0) {
-        effect_mis[i] <- effect[which(effect$variant == colnames(mis_mat_collapsed)[i]), ]$effect
-    }
-}
-
-## syn
-if (length(which(effect$variant == "syn_UR")) == 0) {
-    effect_syn_UR <- 0
-} else {
-    effect_syn_UR <- effect[which(effect$variant == "syn_UR"), ]$effect
-}
-
-effect_syn <- rep(effect_syn_UR, ncol(syn_mat_collapsed))
-
-for (i in 1:(ncol(syn_mat_collapsed) - 1)) {
-    if (length(which(effect$variant == colnames(syn_mat_collapsed)[i])) != 0) {
-        effect_syn[i] <- effect[which(effect$variant == colnames(syn_mat_collapsed)[i]), ]$effect
-    }
-}
+effect_lof <- map_effects(lof_mat_collapsed, effect, "lof_UR", lof_flipped)
+effect_mis <- map_effects(mis_mat_collapsed, effect, "mis_UR", mis_flipped)
+effect_syn <- map_effects(syn_mat_collapsed, effect, "syn_UR", syn_flipped)
 
 print("Effect size is loaded.")
 
 ## Calculate PRS
+calc_group_prs <- function(mat, eff) {
+    if (ncol(mat) == 0) return(Matrix::Matrix(0, nrow = nrow(mat), ncol = 1, sparse = TRUE))
+    mat %*% eff
+}
 
-lof_prs <- lof_mat_collapsed %*% effect_lof
-mis_prs <- mis_mat_collapsed %*% effect_mis
-syn_prs <- syn_mat_collapsed %*% effect_syn
+lof_prs <- calc_group_prs(lof_mat_collapsed, effect_lof)
+mis_prs <- calc_group_prs(mis_mat_collapsed, effect_mis)
+syn_prs <- calc_group_prs(syn_mat_collapsed, effect_syn)
 total_prs <- lof_prs + mis_prs + syn_prs
-out <- cbind(rownames(total_prs), total_prs[,1])
-out <- as.data.frame(out)
-colnames(out) <- c("IID", "PRS")
+
+## Determine sample IDs robustly: an empty group's PRS matrix (a zero column) carries no
+## rownames, so rownames(total_prs) can be NULL when LoF (the first addend) is empty.
+sample_ids <- rownames(lof_mat_collapsed)
+if (is.null(sample_ids)) sample_ids <- rownames(mis_mat_collapsed)
+if (is.null(sample_ids)) sample_ids <- rownames(syn_mat_collapsed)
+if (is.null(sample_ids)) sample_ids <- sampleID
+
+out <- data.frame(
+    IID = sample_ids,
+    PRS_lof = as.numeric(lof_prs[, 1]),
+    PRS_mis = as.numeric(mis_prs[, 1]),
+    PRS_syn = as.numeric(syn_prs[, 1]),
+    PRS = as.numeric(total_prs[, 1]),
+    stringsAsFactors = FALSE
+)
 
 ## Save PRS
 write.table(out, paste0(args$outputPrefix, "_", geneName, "_score.txt"), quote=FALSE, row.names=FALSE, col.names=TRUE, sep="\t")
-write.table(out, "test.txt", quote=FALSE, row.names=FALSE, col.names=TRUE, sep="\t")


### PR DESCRIPTION
Output:
- _effect.txt: SAIGE-style columns (CHR POS MarkerID Allele1 Allele2 annotation is_UR AC_Allele2 AF_Allele2 BETA SE); REF/ALT and POS are read from the bim and reported on the ALT (effect) allele. Removed the redundant PEV column and the internal is_flipped column.
- _h2.txt: group labels harmonized to lof / missense / synonymous / all.
- No spurious all-zero *_UR rows when a group has no ultra-rare variants.
- PRS script: per-group breakdown columns (PRS_lof/PRS_mis/PRS_syn/PRS), robust IID handling, input-file validation, and test-set allele-matched effect application.

Efficiency / cleanup:
- Vectorized calc_log_lik; removed the dense diagonal in calc_post_beta; reuse GtG; vectorized variant-ID parsing. Removed the dead Run_Existing_Approach; fixed var = var.

Bug fixes:
- read_matrix_by_one_marker: Unified_getOneMarker returns missing genotypes as a large sentinel (~2^64), not -1. The previous code counted these as carriers, which overflowed the allele sum and spuriously flipped any variant with missing genotypes; such variants were then silently dropped. Treat values outside [0, 2] as missing (impute to 0) before the allele-sum / flip decision. Variants with genotype missingness are now retained.
- Binary-trait gene heritability numerator now uses the unweighted tr(G^T G) on the original genotype (working-residual scale), not the v-weighted standardized design. Quantitative heritability is unchanged.
- Joint BLUP path reports the joint prediction-error variance (cross-group covariance) for SE.
- Firth L2-penalized fit falls back to the unpenalized estimate on non-convergence (iter < maxit).
- adaptive ridge: corrected relative convergence criterion; no longer crashes when an annotation group is empty; uses the sqrt(v)*G working design for binary traits.
- Keep missing genotypes as 0 after an allele flip; correct chol transpose in the (dormant) Sigma code paths.